### PR TITLE
[cicd] 배포 스크립트에서 nginx 폴더와 docker-compose.yml 경로 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # 변수 설정
-COMPOSE_PATH="./docker-compose.yml"
-NGINX_CONF_DIR="./nginx"
+COMPOSE_PATH="home/ec2-user/docker-compose.yml"
+NGINX_CONF_DIR="home/ec2-user/nginx"
 DELAY=5
 NGINX_CONTAINER="nginx"
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #66 

## 📌 개요
- Code Deploy의 배포 로그를 살펴보니 상대경로가 잘못되어 에러가 발생한 것으로 보입니다
 <img src="https://github.com/user-attachments/assets/3e4d32ee-c4ea-4313-86d7-3ef2b70f17ea" width=400/>

- Code Deploy가 실행하는 배포 스크립트인 deploy.sh 파일에서 nginx 관련 파일과 docker compose 파일 경로를 수정합니다.
- 제발 되었으면 합니다.

> 실수로 절대경로가 아닌 상대경로(home/ec2-user)를 앞에 추가하고 머지하여 부득이하게 절대경로를 바꾸는 커밋만 develop 브랜치로 바로 푸시했습니다!

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
