### PR TITLE
[cicd] docker-compose 명령어를 docker compose로 변경

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,7 +41,7 @@ fi
 echo
 echo "-----------------------------"
 echo "새로운 환경 이미지 빌드 중: $NEW_API_ENV & $NEW_AI_ENV (캐시 무시)"
-docker-compose -f "$COMPOSE_PATH" build --no-cache $NEW_API_ENV $NEW_AI_ENV
+docker compose -f "$COMPOSE_PATH" build --no-cache $NEW_API_ENV $NEW_AI_ENV
 echo "-----------------------------"
 echo
 
@@ -49,8 +49,8 @@ echo
 echo
 echo "-----------------------------"
 echo "새로운 환경 시작 중: $NEW_API_ENV & $NEW_AI_ENV"
-docker-compose -f "$COMPOSE_PATH" up -d --no-deps $NEW_API_ENV
-docker-compose -f "$COMPOSE_PATH" up -d --no-deps $NEW_AI_ENV
+docker compose -f "$COMPOSE_PATH" up -d --no-deps $NEW_API_ENV
+docker compose -f "$COMPOSE_PATH" up -d --no-deps $NEW_AI_ENV
 echo "-----------------------------"
 echo
 
@@ -72,7 +72,7 @@ echo
 echo
 echo "-----------------------------"
 echo "Nginx 리로드 중..."
-docker-compose -f "$COMPOSE_PATH" exec "$NGINX_CONTAINER" nginx -s reload
+docker compose -f "$COMPOSE_PATH" exec "$NGINX_CONTAINER" nginx -s reload
 echo "-----------------------------"
 echo
 
@@ -80,10 +80,10 @@ echo
 echo
 echo "-----------------------------"
 echo "이전 환경 중지 및 제거 중: $CURRENT_API_ENV & $CURRENT_AI_ENV"
-docker-compose -f "$COMPOSE_PATH" stop "$CURRENT_API_ENV"
-docker-compose -f "$COMPOSE_PATH" stop "$CURRENT_AI_ENV"
-docker-compose -f "$COMPOSE_PATH" rm -f "$CURRENT_API_ENV"
-docker-compose -f "$COMPOSE_PATH" rm -f "$CURRENT_AI_ENV"
+docker compose -f "$COMPOSE_PATH" stop "$CURRENT_API_ENV"
+docker compose -f "$COMPOSE_PATH" stop "$CURRENT_AI_ENV"
+docker compose -f "$COMPOSE_PATH" rm -f "$CURRENT_API_ENV"
+docker compose -f "$COMPOSE_PATH" rm -f "$CURRENT_AI_ENV"
 echo "-----------------------------"
 echo
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수

## ❗️ 관련 이슈 링크
Close #68 

## 📌 개요
- docker-compose 명령어를 docker compose로 변경합니다.

## 🔁 변경 사항
- 배포 로그를 확인한 결과, deploy.sh 파일에서 docker-compose.yml과 Nginx 관련 파일 경로를 로컬 테스트 중에 상대 경로 (`./nginx`, `./docker-compose.yml`)로 지정한 것이 문제였습니다. 이를 절대 경로인 `/home/ec2/nginx`, `/home/ec2/docker-compose.yml`로 수정하여 Nginx 경로 문제는 해결되었습니다.

- 그러나 여전히 docker-compose 명령어를 찾지 못하는 오류가 발생 ➡️ 이는 최근 GitHub에서 Docker Compose가 v1에서 v2로 업데이트되면서 발생한 문제로 보입니다. 
- [Docker Compose V2 Migration Guide](https://github.com/orgs/community/discussions/116610)를 보니 Docker Compose v2에서는 기존의 docker-compose 명령어 대신 docker compose (하이픈 없이) 명령어를 사용해야 하는 것으로 보입니다. 따라서 이를 수정했습니다.

=> 해결 안 됨 (docker 명령어로 인식하고, docker-compose 명령어로 인식하지 않음)

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
