### PR TITLE
[fix] 관리자 refresh 토큰 및 access 토큰 재발급 API 수정

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
@@ -18,6 +18,7 @@ import aurora.carevisionapiserver.domain.nurse.dto.request.NurseRequest.NurseSig
 import aurora.carevisionapiserver.domain.nurse.dto.response.NurseResponse.NurseInfoResponse;
 import aurora.carevisionapiserver.domain.nurse.service.NurseService;
 import aurora.carevisionapiserver.global.auth.converter.AuthConverter;
+import aurora.carevisionapiserver.global.auth.domain.Role;
 import aurora.carevisionapiserver.global.auth.dto.request.AuthRequest.LoginRequest;
 import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.LoginResponse;
 import aurora.carevisionapiserver.global.auth.service.AuthService;
@@ -96,6 +97,8 @@ public class NurseAuthController {
 
         String username = loginRequest.getUsername();
         String password = loginRequest.getPassword();
+
+        authService.validateUsername(username, Role.NURSE);
 
         return authService
                 .authenticate(username, password)

--- a/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
@@ -29,8 +29,7 @@ public class ReissueController {
 
     @Operation(
             summary = "관리자 refresh 및 access 토큰 재발급 API",
-            description =
-                    "refresh token과 access 토큰을 body에 재발급합니다_예림")
+            description = "refresh token과 access 토큰을 body에 재발급합니다_예림")
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })

--- a/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
@@ -59,7 +59,6 @@ public class ReissueController {
             @Parameter(name = "admin", hidden = true) @AuthUser Nurse nurse,
             HttpServletRequest request) {
         String refreshToken = request.getHeader(AUTHORIZATION_HEADER);
-        System.out.println(refreshToken);
         LoginResponse loginResponse = authService.handleReissue(refreshToken);
         return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
     }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
@@ -7,12 +7,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
+import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.LoginResponse;
 import aurora.carevisionapiserver.global.auth.service.AuthService;
 import aurora.carevisionapiserver.global.error.BaseResponse;
 import aurora.carevisionapiserver.global.error.code.status.SuccessStatus;
 import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
-import aurora.carevisionapiserver.global.security.handler.annotation.ExtractToken;
 import aurora.carevisionapiserver.global.security.handler.annotation.RefreshTokenApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,8 +31,9 @@ public class ReissueController {
     public static final String AUTHORIZATION_HEADER = "Authorization";
 
     @Operation(
-            summary = "관리자 refresh 토큰 재발급 API",
-            description = "refresh 토큰이 만료된 경우 refresh 토큰과 access 토큰을 body에 재발급합니다_예림")
+            summary = "관리자 refresh 및 access 토큰 재발급 API",
+            description =
+                    "access token이 만료되면 Authoriazation 헤더에 refresh token을 넣어 요청하여 access 토큰을 body에 재발급합니다_예림")
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
@@ -41,10 +42,8 @@ public class ReissueController {
     public BaseResponse<LoginResponse> reissueForAdmin(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
             HttpServletRequest request) {
-        String role = authService.getCurrentUserRole();
-        String refreshToken = request.getHeader(AUTHORIZATION_HEADER);
-        System.out.println("눈물 차올라~" + role + refreshToken);
-        LoginResponse loginResponse = authService.handleReissue(refreshToken);
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+        LoginResponse loginResponse = authService.handleReissue(authorizationHeader);
         return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
     }
 
@@ -57,8 +56,10 @@ public class ReissueController {
     @RefreshTokenApiResponse
     @PostMapping("/api/reissue")
     public BaseResponse<LoginResponse> reissueForNurse(
-            @Parameter(hidden = true) @ExtractToken String refreshToken) {
-        //        String role = authService.getCurrentUserRole();
+            @Parameter(name = "admin", hidden = true) @AuthUser Nurse nurse,
+            HttpServletRequest request) {
+        String refreshToken = request.getHeader(AUTHORIZATION_HEADER);
+        System.out.println(refreshToken);
         LoginResponse loginResponse = authService.handleReissue(refreshToken);
         return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
     }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
@@ -1,9 +1,7 @@
 package aurora.carevisionapiserver.global.auth.api;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
@@ -13,6 +11,7 @@ import aurora.carevisionapiserver.global.auth.service.AuthService;
 import aurora.carevisionapiserver.global.error.BaseResponse;
 import aurora.carevisionapiserver.global.error.code.status.SuccessStatus;
 import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
+import aurora.carevisionapiserver.global.security.handler.annotation.ExtractToken;
 import aurora.carevisionapiserver.global.security.handler.annotation.RefreshTokenApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,37 +27,33 @@ import lombok.RequiredArgsConstructor;
 public class ReissueController {
     private final AuthService authService;
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-
     @Operation(
             summary = "관리자 refresh 및 access 토큰 재발급 API",
             description =
-                    "access token이 만료되면 Authoriazation 헤더에 refresh token을 넣어 요청하여 access 토큰을 body에 재발급합니다_예림")
+                    "refresh token과 access 토큰을 body에 재발급합니다_예림")
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     @RefreshTokenApiResponse
-    @PostMapping("/api/admin/reissue")
+    @GetMapping("/api/admin/reissue")
     public BaseResponse<LoginResponse> reissueForAdmin(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
-            HttpServletRequest request) {
-        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
-        LoginResponse loginResponse = authService.handleReissue(authorizationHeader);
+            @ExtractToken String refreshToken) {
+        LoginResponse loginResponse = authService.handleReissue(refreshToken);
         return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
     }
 
     @Operation(
             summary = "간호사 refresh 및 access 토큰 재발급 API",
-            description = "refresh 토큰이 만료된 경우 refresh 토큰과 access 토큰을 body에 재발급합니다_예림")
+            description = "refresh token과 access 토큰을 body에 재발급합니다_예림")
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     @RefreshTokenApiResponse
-    @PostMapping("/api/reissue")
+    @GetMapping("/api/reissue")
     public BaseResponse<LoginResponse> reissueForNurse(
             @Parameter(name = "admin", hidden = true) @AuthUser Nurse nurse,
-            HttpServletRequest request) {
-        String refreshToken = request.getHeader(AUTHORIZATION_HEADER);
+            @ExtractToken String refreshToken) {
         LoginResponse loginResponse = authService.handleReissue(refreshToken);
         return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
     }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
@@ -48,7 +48,7 @@ public class ReissueController {
     }
 
     @Operation(
-            summary = "간호사 refresh 토큰 재발급 API",
+            summary = "간호사 refresh 및 access 토큰 재발급 API",
             description = "refresh 토큰이 만료된 경우 refresh 토큰과 access 토큰을 body에 재발급합니다_예림")
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),

--- a/src/main/java/aurora/carevisionapiserver/global/auth/domain/CustomUserDetailsNurse.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/domain/CustomUserDetailsNurse.java
@@ -10,7 +10,7 @@ import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class CustomUserDetails implements UserDetails {
+public class CustomUserDetailsNurse implements UserDetails {
     private final Nurse nurse;
 
     @Override

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/AuthService.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/AuthService.java
@@ -24,5 +24,5 @@ public interface AuthService {
 
     void validateUsername(String username, Role role);
 
-    LoginResponse handleReissue(String refreshToken);
+    LoginResponse handleReissue(String authorizationHeader);
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/CustomUserDetailsService.java
@@ -9,8 +9,8 @@ import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.admin.repository.AdminRepository;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
-import aurora.carevisionapiserver.global.auth.domain.CustomUserDetails;
 import aurora.carevisionapiserver.global.auth.domain.CustomUserDetailsAdmin;
+import aurora.carevisionapiserver.global.auth.domain.CustomUserDetailsNurse;
 import aurora.carevisionapiserver.global.auth.exception.AuthException;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +34,6 @@ public class CustomUserDetailsService implements UserDetailsService {
                         .findByUsername(username)
                         .orElseThrow(() -> new AuthException(ErrorStatus.USERNAME_NOT_FOUND));
 
-        return new CustomUserDetails(nurse);
+        return new CustomUserDetailsNurse(nurse);
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/Impl/AuthServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/Impl/AuthServiceImpl.java
@@ -124,14 +124,12 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public LoginResponse handleReissue(String authorizationHeader) {
-        if (authorizationHeader == null) {
+    public LoginResponse handleReissue(String refreshToken) {
+        if (refreshToken == null) {
             throw new AuthException(ErrorStatus.REFRESH_TOKEN_NULL);
         }
 
-        String parsedToken = parseBearerToken(authorizationHeader);
-
-        String username = jwtUtil.getId(parsedToken);
+        String username = jwtUtil.getId(refreshToken);
 
         try {
             refreshTokenRepository
@@ -162,12 +160,5 @@ public class AuthServiceImpl implements AuthService {
                         .expiration(date.toString())
                         .build();
         refreshTokenRepository.save(newRefreshToken);
-    }
-
-    public String parseBearerToken(String authorizationHeader) {
-        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
-            throw new AuthException(ErrorStatus.AUTH_HEADER_MISSING_OR_INVALID);
-        }
-        return authorizationHeader.substring(BEARER_PREFIX.length());
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/util/JWTFilter.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/util/JWTFilter.java
@@ -18,8 +18,8 @@ import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.admin.repository.AdminRepository;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
-import aurora.carevisionapiserver.global.auth.domain.CustomUserDetails;
 import aurora.carevisionapiserver.global.auth.domain.CustomUserDetailsAdmin;
+import aurora.carevisionapiserver.global.auth.domain.CustomUserDetailsNurse;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
 import aurora.carevisionapiserver.global.error.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -48,7 +48,7 @@ public class JWTFilter extends OncePerRequestFilter {
                 UserDetails userDetails = null;
                 if (nurseRepository.existsByUsername(username)) {
                     Optional<Nurse> nurse = nurseRepository.findByUsername(username);
-                    userDetails = new CustomUserDetails(nurse.get());
+                    userDetails = new CustomUserDetailsNurse(nurse.get());
                 }
                 if (adminRepository.existsByUsername(username)) {
                     Optional<Admin> admin = adminRepository.findByUsername(username);

--- a/src/main/java/aurora/carevisionapiserver/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/aurora/carevisionapiserver/global/error/code/status/ErrorStatus.java
@@ -38,6 +38,8 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_ACTIVATED(HttpStatus.FORBIDDEN, "AUTH407", "승인되지 않은 유저입니다."),
     INVALID_ROLE(HttpStatus.FORBIDDEN, "AUTH408", "유효하지 않은 권한입니다."),
     UNAUTHORIZED_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH409", "인증되지 않은 요청입니다."),
+    AUTH_HEADER_MISSING_OR_INVALID(
+            HttpStatus.BAD_REQUEST, "AUTH410", "Authorization 헤더가 없거나 유효하지 않습니다."),
 
     // Admin
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN400", "관리자를 찾을 수 없습니다."),

--- a/src/main/java/aurora/carevisionapiserver/global/fcm/api/FcmController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/fcm/api/FcmController.java
@@ -49,8 +49,8 @@ public class FcmController {
     @PostMapping("/alarm/{patientId}")
     public BaseResponse<Void> sendAlarm(@PathVariable(name = "patientId") Long patientId) {
         Patient patient = patientService.getPatient(patientId);
-        //TODO
-        //String token = fcmService.findClientToken(patient.getNurse());
+        // TODO
+        // String token = fcmService.findClientToken(patient.getNurse());
 
         fcmService.abnormalBehaviorAlarm(patient, "refresh");
 

--- a/src/main/java/aurora/carevisionapiserver/global/security/handler/resolver/ExtractTokenArgumentResolver.java
+++ b/src/main/java/aurora/carevisionapiserver/global/security/handler/resolver/ExtractTokenArgumentResolver.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ExtractTokenArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final JWTUtil jwtTokenProvider;
+    private final JWTUtil jwtUtil;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -38,7 +38,7 @@ public class ExtractTokenArgumentResolver implements HandlerMethodArgumentResolv
         }
 
         String token = authorizationHeader.substring(7);
-        jwtTokenProvider.isValidToken(token);
+        jwtUtil.isValidToken(token);
         return token;
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #147 

## 📌 개요
- 기존에 수정한 간호사 토큰 재발급 API에 따라 관리자 토큰 재발급 API `POST /api/reissue`를 수정했습니다.

## 🔁 변경 사항
- Nurse에 대한 `CustomUserDetails`를 Admin과 구분하기 위해서`CustomUserDetailsNurse`로 변경했습니다!
- 현재 배포 서버에 올라간 간호사 refresh API는 작동이 잘 되는데, 로컬에서는 계속해서 다음과 같은 오류가 발생했습니다. (JWT 토큰의 디코딩 중 문제 발생)
  
  <details>
    <summary>에러 메시지 보기</summary>
  
  
  ```
  2024-11-24T18:50:43.391+09:00 ERROR 64564 --- [CareVision] [nio-8080-exec-9] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: io.jsonwebtoken.io.DecodingException: Illegal base64url character: ' '] with root cause
  
  io.jsonwebtoken.io.DecodingException: Illegal base64url character: ' '
	  at io.jsonwebtoken.io.Base64.ctoi(Base64.java:221) ~[jjwt-api-0.11.5.jar:0.11.5]
	  at io.jsonwebtoken.io.Base64.decodeFast(Base64.java:270) ~[jjwt-api-0.11.5.jar:0.11.5]
	  at io.jsonwebtoken.io.Base64Decoder.decode(Base64Decoder.java:36) ~[jjwt-api-0.11.5.jar:0.11.5]
	  at io.jsonwebtoken.io.Base64Decoder.decode(Base64Decoder.java:23) ~[jjwt-api-0.11.5.jar:0.11.5]
	  at io.jsonwebtoken.io.ExceptionPropagatingDecoder.decode(ExceptionPropagatingDecoder.java:36) ~[jjwt-api-0.11.5.jar:0.11.5]
	  at io.jsonwebtoken.impl.DefaultJwtParser.parse(DefaultJwtParser.java:288) ~[jjwt-impl-0.11.5.jar:0.11.5]
	  at io.jsonwebtoken.impl.DefaultJwtParser.parse(DefaultJwtParser.java:529) ~[jjwt-impl-0.11.5.jar:0.11.5]
	  at io.jsonwebtoken.impl.DefaultJwtParser.parseClaimsJws(DefaultJwtParser.java:589) ~[jjwt-impl-0.11.5.jar:0.11.5]
	  at io.jsonwebtoken.impl.ImmutableJwtParser.parseClaimsJws(ImmutableJwtParser.java:173) ~[jjwt-impl-0.11.5.jar:0.11.5]
	  at aurora.carevisionapiserver.global.auth.util.JWTUtil.getClaims(JWTUtil.java:58) ~[main/:na]
	  at aurora.carevisionapiserver.global.auth.util.JWTUtil.getId(JWTUtil.java:63) ~[main/:na]
	  at aurora.carevisionapiserver.global.auth.service.Impl.AuthServiceImpl.handleReissue(AuthServiceImpl.java:131) ~[main/:na]
	  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	  at java.base/java.lang.reflect.Method.invoke(Method.java:569) ~[na:na]
	  at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:355) ~[spring-aop-6.1.13.jar:6.1.13]
	  at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:716) ~[spring-aop-6.1.13.jar:6.1.13]
	  at aurora.carevisionapiserver.global.auth.service.Impl.AuthServiceImpl$$SpringCGLIB$$0.handleReissue(<generated>) ~[main/:na]
	  at aurora.carevisionapiserver.global.auth.api.ReissueController.reissueForAdmin(ReissueController.java:46) ~[main/:na]
	  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	  at java.base/java.lang.reflect.Method.invoke(Method.java:569) ~[na:na]
	  at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:255) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:188) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:926) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:831) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1089) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:979) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:914) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:590) ~[tomcat-embed-core-10.1.30.jar:6.0]
	  at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:885) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658) ~[tomcat-embed-core-10.1.30.jar:6.0]
	  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51) ~[tomcat-embed-websocket-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:110) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:108) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.security.web.FilterChainProxy.lambda$doFilterInternal$3(FilterChainProxy.java:231) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:365) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.access.intercept.AuthorizationFilter.doFilter(AuthorizationFilter.java:100) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:126) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:120) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:131) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.session.SessionManagementFilter.doFilter(SessionManagementFilter.java:85) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:100) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFilter.java:179) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at aurora.carevisionapiserver.global.auth.util.JWTFilter.doFilterInternal(JWTFilter.java:73) ~[main/:na]
	  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:107) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:93) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter(HeaderWriterFilter.java:90) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:75) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:82) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:69) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:62) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.session.DisableEncodeUrlFilter.doFilterInternal(DisableEncodeUrlFilter.java:42) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:374) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:233) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:191) ~[spring-security-web-6.3.3.jar:6.3.3]
	  at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.servlet.handler.HandlerMappingIntrospector.lambda$createCacheFilter$3(HandlerMappingIntrospector.java:195) ~[spring-webmvc-6.1.13.jar:6.1.13]
	  at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.filter.CompositeFilter.doFilter(CompositeFilter.java:74) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.security.config.annotation.web.configuration.WebMvcSecurityConfiguration$CompositeFilterChainProxy.doFilter(WebMvcSecurityConfiguration.java:230) ~[spring-security-config-6.3.3.jar:6.3.3]
	  at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:352) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:268) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.springframework.session.web.http.SessionRepositoryFilter.doFilterInternal(SessionRepositoryFilter.java:142) ~[spring-session-core-3.3.2.jar:3.3.2]
	  at org.springframework.session.web.http.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:82) ~[spring-session-core-3.3.2.jar:3.3.2]
	  at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:352) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:268) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116) ~[spring-web-6.1.13.jar:6.1.13]
	  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:483) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:384) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:905) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1741) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1190) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63) ~[tomcat-embed-core-10.1.30.jar:10.1.30]
	  at java.base/java.lang.Thread.run(Thread.java:840) ~[na:na]
  ```
  
  </details>

- 로그를 찍어보니 JwtUtils의 getId에서 호출하는 getClaims 메서드 내의 `Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token)`코드에서 문제가 발생했습니다.
- 토큰 앞의 `Bearer `를 parse하지 않은 채로 토큰을 받아오는 것이 문제라고 생각해 `parseBearerToken` 메서드를 추가해주었더니 해결되었습니다.
  - 다만... 배포 서버에서는 잘 되는데 왜..? 🤔
- 이 parseBearerToken 메서드를 Util 클래스에 따로 넣어서 다음과 같이 doFilterInteral 메서드에도 사용하려고 했으나 에러를 throw할 때 에러 헨들러가 doFilterInteral에서는 작동하지 않아 그냥 parseBearerToken을 여기서 재사용하지는 않고 그대로 두었습니다.
 
  
  ```java
  // 이 로직을
  if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
     String parsedToken = authorizationHeader.substring(7);
  
      if (jwtUtil.isValidToken(parsedToken)) {
                      String username = jwtUtil.getId(parsedToken);
  ```
  ```java
  // 이 로직으로 수정하려고 했었지만 일단 다음에..
  String parsedToken = parseBearerToken(authorizationHeader);  // 유효하지 않으면 에러 throw
  if (jwtUtil.isValidToken(parsedToken)) {
                  String username = jwtUtil.getId(parsedToken);
  ```



## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
