### PR TITLE
[feat] 관리자 & 간호사 로그아웃 API 

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/admin/api/AdminAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/admin/api/AdminAuthController.java
@@ -99,9 +99,7 @@ public class AdminAuthController {
         return authService
                 .authenticate(username, password)
                 .map(
-                        authentication -> {
-                            return BaseResponse.onSuccess(authService.generateTokens(username));
-                        })
+                        authentication -> BaseResponse.onSuccess(authService.generateTokens(username)))
                 .orElse(
                         BaseResponse.onFailure(
                                 ErrorStatus.INVALID_CREDENTIALS.getCode(),

--- a/src/main/java/aurora/carevisionapiserver/domain/admin/api/AdminAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/admin/api/AdminAuthController.java
@@ -98,8 +98,7 @@ public class AdminAuthController {
         String password = adminLoginRequest.getPassword();
         return authService
                 .authenticate(username, password)
-                .map(
-                        authentication -> BaseResponse.onSuccess(authService.generateTokens(username)))
+                .map(authentication -> BaseResponse.onSuccess(authService.generateTokens(username)))
                 .orElse(
                         BaseResponse.onFailure(
                                 ErrorStatus.INVALID_CREDENTIALS.getCode(),

--- a/src/main/java/aurora/carevisionapiserver/domain/admin/api/AdminAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/admin/api/AdminAuthController.java
@@ -1,10 +1,9 @@
 package aurora.carevisionapiserver.domain.admin.api;
 
-import static aurora.carevisionapiserver.global.auth.converter.AuthConverter.toLoginResponse;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,12 +21,15 @@ import aurora.carevisionapiserver.domain.hospital.dto.request.HospitalRequest.Ho
 import aurora.carevisionapiserver.domain.hospital.service.HospitalService;
 import aurora.carevisionapiserver.global.auth.domain.Role;
 import aurora.carevisionapiserver.global.auth.dto.request.AuthRequest.LoginRequest;
-import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.LoginResponse;
+import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.TokenResponse;
 import aurora.carevisionapiserver.global.auth.service.AuthService;
 import aurora.carevisionapiserver.global.error.BaseResponse;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
 import aurora.carevisionapiserver.global.error.code.status.SuccessStatus;
+import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
+import aurora.carevisionapiserver.global.security.handler.annotation.ExtractToken;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -87,7 +89,7 @@ public class AdminAuthController {
         @ApiResponse(responseCode = "AUTH404", description = "인증에 실패했습니다.")
     })
     @PostMapping("/login")
-    public BaseResponse<LoginResponse> login(@RequestBody LoginRequest adminLoginRequest) {
+    public BaseResponse<TokenResponse> login(@RequestBody LoginRequest adminLoginRequest) {
 
         String username = adminLoginRequest.getUsername();
 
@@ -98,16 +100,27 @@ public class AdminAuthController {
                 .authenticate(username, password)
                 .map(
                         authentication -> {
-                            String accessToken = authService.createAccessToken(username, "ADMIN");
-                            String refreshToken = authService.createRefreshToken(username, "ADMIN");
-
-                            return BaseResponse.onSuccess(
-                                    toLoginResponse(accessToken, refreshToken));
+                            return BaseResponse.onSuccess(authService.generateTokens(username));
                         })
                 .orElse(
                         BaseResponse.onFailure(
                                 ErrorStatus.INVALID_CREDENTIALS.getCode(),
                                 ErrorStatus.INVALID_CREDENTIALS.getMessage(),
                                 null));
+    }
+
+    @Operation(
+            summary = "관리자 로그아웃 API",
+            description = "관리자가 서비스에 로그아웃합니다. DB에 있는 리프레시 토큰 삭제를 위해 refresh 토큰을 받습니다._예림")
+    @ApiResponses({
+        @ApiResponse(responseCode = "COMMON202", description = "OK, 요청 성공 및 반환할 콘텐츠 없음"),
+        @ApiResponse(responseCode = "AUTH404", description = "인증에 실패했습니다.")
+    })
+    @PostMapping("/logout")
+    public BaseResponse<TokenResponse> logout(
+            @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
+            @RequestHeader("refreshToken") @ExtractToken String refreshToken) {
+        authService.logout(admin.getId(), refreshToken);
+        return BaseResponse.of(SuccessStatus._NO_CONTENT, null);
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
@@ -105,8 +105,7 @@ public class NurseAuthController {
 
         return authService
                 .authenticate(username, password)
-                .map(
-                        authentication -> BaseResponse.onSuccess(authService.generateTokens(username)))
+                .map(authentication -> BaseResponse.onSuccess(authService.generateTokens(username)))
                 .orElse(
                         BaseResponse.onFailure(
                                 ErrorStatus.INVALID_CREDENTIALS.getCode(),

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
@@ -17,10 +17,9 @@ import aurora.carevisionapiserver.domain.nurse.dto.request.NurseRequest.NurseCre
 import aurora.carevisionapiserver.domain.nurse.dto.request.NurseRequest.NurseSignUpRequest;
 import aurora.carevisionapiserver.domain.nurse.dto.response.NurseResponse.NurseInfoResponse;
 import aurora.carevisionapiserver.domain.nurse.service.NurseService;
-import aurora.carevisionapiserver.global.auth.converter.AuthConverter;
 import aurora.carevisionapiserver.global.auth.domain.Role;
 import aurora.carevisionapiserver.global.auth.dto.request.AuthRequest.LoginRequest;
-import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.LoginResponse;
+import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.TokenResponse;
 import aurora.carevisionapiserver.global.auth.service.AuthService;
 import aurora.carevisionapiserver.global.error.BaseResponse;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
@@ -92,7 +91,7 @@ public class NurseAuthController {
         @ApiResponse(responseCode = "AUTH407", description = "승인되지 않은 유저입니다."),
     })
     @PostMapping("/login")
-    public BaseResponse<LoginResponse> login(
+    public BaseResponse<TokenResponse> login(
             @RequestBody @IsActivateNurse LoginRequest loginRequest) {
 
         String username = loginRequest.getUsername();
@@ -104,11 +103,7 @@ public class NurseAuthController {
                 .authenticate(username, password)
                 .map(
                         authentication -> {
-                            String accessToken = authService.createAccessToken(username, "NURSE");
-                            String refreshToken = authService.createRefreshToken(username, "NURSE");
-
-                            return BaseResponse.onSuccess(
-                                    AuthConverter.toLoginResponse(accessToken, refreshToken));
+                            return BaseResponse.onSuccess(authService.generateTokens(username));
                         })
                 .orElse(
                         BaseResponse.onFailure(

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
@@ -106,9 +106,7 @@ public class NurseAuthController {
         return authService
                 .authenticate(username, password)
                 .map(
-                        authentication -> {
-                            return BaseResponse.onSuccess(authService.generateTokens(username));
-                        })
+                        authentication -> BaseResponse.onSuccess(authService.generateTokens(username)))
                 .orElse(
                         BaseResponse.onFailure(
                                 ErrorStatus.INVALID_CREDENTIALS.getCode(),

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseAuthController.java
@@ -4,6 +4,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,8 +25,11 @@ import aurora.carevisionapiserver.global.auth.service.AuthService;
 import aurora.carevisionapiserver.global.error.BaseResponse;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
 import aurora.carevisionapiserver.global.error.code.status.SuccessStatus;
+import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
+import aurora.carevisionapiserver.global.security.handler.annotation.ExtractToken;
 import aurora.carevisionapiserver.global.util.validation.annotation.IsActivateNurse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -110,5 +114,20 @@ public class NurseAuthController {
                                 ErrorStatus.INVALID_CREDENTIALS.getCode(),
                                 ErrorStatus.INVALID_CREDENTIALS.getMessage(),
                                 null));
+    }
+
+    @Operation(
+            summary = "간호사 로그아웃 API",
+            description = "간호사가 서비스에 로그아웃합니다. DB에 있는 리프레시 토큰 삭제를 위해 refresh 토큰을 받습니다._예림")
+    @ApiResponses({
+        @ApiResponse(responseCode = "COMMON202", description = "OK, 요청 성공 및 반환할 콘텐츠 없음"),
+        @ApiResponse(responseCode = "AUTH404", description = "인증에 실패했습니다.")
+    })
+    @PostMapping("/logout")
+    public BaseResponse<TokenResponse> logout(
+            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
+            @RequestHeader("refreshToken") @ExtractToken String refreshToken) {
+        authService.logout(nurse.getId(), refreshToken);
+        return BaseResponse.of(SuccessStatus._NO_CONTENT, null);
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
@@ -37,7 +37,7 @@ public class ReissueController {
     @GetMapping("/api/admin/reissue")
     public BaseResponse<LoginResponse> reissueForAdmin(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
-            @ExtractToken String refreshToken) {
+            @Parameter(hidden = true) @ExtractToken String refreshToken) {
         LoginResponse loginResponse = authService.handleReissue(refreshToken);
         return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
     }
@@ -52,7 +52,7 @@ public class ReissueController {
     @GetMapping("/api/reissue")
     public BaseResponse<LoginResponse> reissueForNurse(
             @Parameter(name = "admin", hidden = true) @AuthUser Nurse nurse,
-            @ExtractToken String refreshToken) {
+            @Parameter(hidden = true) @ExtractToken String refreshToken) {
         LoginResponse loginResponse = authService.handleReissue(refreshToken);
         return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
     }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/api/ReissueController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
-import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.LoginResponse;
+import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.TokenResponse;
 import aurora.carevisionapiserver.global.auth.service.AuthService;
 import aurora.carevisionapiserver.global.error.BaseResponse;
 import aurora.carevisionapiserver.global.error.code.status.SuccessStatus;
@@ -35,11 +35,11 @@ public class ReissueController {
     })
     @RefreshTokenApiResponse
     @GetMapping("/api/admin/reissue")
-    public BaseResponse<LoginResponse> reissueForAdmin(
+    public BaseResponse<TokenResponse> reissueForAdmin(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
             @Parameter(hidden = true) @ExtractToken String refreshToken) {
-        LoginResponse loginResponse = authService.handleReissue(refreshToken);
-        return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
+        TokenResponse tokenResponse = authService.handleReissue(refreshToken);
+        return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, tokenResponse);
     }
 
     @Operation(
@@ -50,10 +50,10 @@ public class ReissueController {
     })
     @RefreshTokenApiResponse
     @GetMapping("/api/reissue")
-    public BaseResponse<LoginResponse> reissueForNurse(
+    public BaseResponse<TokenResponse> reissueForNurse(
             @Parameter(name = "admin", hidden = true) @AuthUser Nurse nurse,
             @Parameter(hidden = true) @ExtractToken String refreshToken) {
-        LoginResponse loginResponse = authService.handleReissue(refreshToken);
-        return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, loginResponse);
+        TokenResponse tokenResponse = authService.handleReissue(refreshToken);
+        return BaseResponse.of(SuccessStatus.REFRESH_TOKEN_ISSUED, tokenResponse);
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/converter/AuthConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/converter/AuthConverter.java
@@ -1,9 +1,9 @@
 package aurora.carevisionapiserver.global.auth.converter;
 
-import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.LoginResponse;
+import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.TokenResponse;
 
 public class AuthConverter {
-    public static LoginResponse toLoginResponse(String accessToken, String refreshToken) {
-        return LoginResponse.builder().accessToken(accessToken).refreshToken(refreshToken).build();
+    public static TokenResponse toTokenResponse(String accessToken, String refreshToken) {
+        return TokenResponse.builder().accessToken(accessToken).refreshToken(refreshToken).build();
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/dto/response/AuthResponse.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/dto/response/AuthResponse.java
@@ -5,12 +5,12 @@ import lombok.Getter;
 
 public class AuthResponse {
     @Getter
-    public static class LoginResponse {
+    public static class TokenResponse {
         private String accessToken;
         private String refreshToken;
 
         @Builder
-        public LoginResponse(String accessToken, String refreshToken) {
+        public TokenResponse(String accessToken, String refreshToken) {
             this.accessToken = accessToken;
             this.refreshToken = refreshToken;
         }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/repository/RefreshTokenRepository.java
@@ -11,7 +11,7 @@ import aurora.carevisionapiserver.global.auth.domain.RefreshToken;
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 
     @Transactional
-    void deleteByUsername(String refreshToken);
+    void deleteByRefreshToken(String refreshToken);
 
     Optional<RefreshToken> findByUsername(String username);
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/AuthService.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/AuthService.java
@@ -5,18 +5,12 @@ import java.util.Optional;
 import org.springframework.security.core.Authentication;
 
 import aurora.carevisionapiserver.global.auth.domain.Role;
-import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.LoginResponse;
+import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.TokenResponse;
 
 public interface AuthService {
     Optional<Authentication> authenticate(String username, String password);
 
-    String createAccessToken(String username, String role);
-
-    String createRefreshToken(String username, String role);
-
-    void saveRefreshToken(String username, String refreshToken, long expiredMs);
-
-    String getCurrentUserRole();
+    TokenResponse generateTokens(String username);
 
     void validateUsername(String username);
 
@@ -24,5 +18,8 @@ public interface AuthService {
 
     void validateUsername(String username, Role role);
 
-    LoginResponse handleReissue(String authorizationHeader);
+    TokenResponse handleReissue(String authorizationHeader);
+
+    void logout(Long id, String refreshToken);
+
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/AuthService.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/AuthService.java
@@ -21,5 +21,4 @@ public interface AuthService {
     TokenResponse handleReissue(String authorizationHeader);
 
     void logout(Long id, String refreshToken);
-
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/Impl/AuthServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/Impl/AuthServiceImpl.java
@@ -18,9 +18,9 @@ import aurora.carevisionapiserver.global.auth.exception.AuthException;
 import aurora.carevisionapiserver.global.auth.repository.RefreshTokenRepository;
 import aurora.carevisionapiserver.global.auth.service.AuthService;
 import aurora.carevisionapiserver.global.auth.util.JWTUtil;
+import aurora.carevisionapiserver.global.auth.util.RefreshTokenValidator;
 import aurora.carevisionapiserver.global.auth.util.TokenGenerator;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
-import aurora.carevisionapiserver.global.util.validation.validator.RefreshTokenValidator;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -82,7 +82,6 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public TokenResponse handleReissue(String refreshToken) {
-        refreshTokenValidator.checkIfTokenNull(refreshToken);
         refreshTokenValidator.validateToken(refreshToken);
         refreshTokenValidator.validateTokenOwnerId(refreshToken);
 
@@ -96,7 +95,6 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public void logout(Long id, String refreshToken) {
-        refreshTokenValidator.checkIfTokenNull(refreshToken);
         refreshTokenValidator.validateToken(refreshToken);
         refreshTokenValidator.validateTokenOwnerId(refreshToken);
 

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/Impl/AuthServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/Impl/AuthServiceImpl.java
@@ -95,5 +95,14 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public void logout(Long id, String refreshToken) {}
+    public void logout(Long id, String refreshToken) {
+        refreshTokenValidator.checkIfTokenNull(refreshToken);
+        refreshTokenValidator.validateToken(refreshToken);
+        refreshTokenValidator.validateTokenOwnerId(refreshToken);
+
+        // 이전 refresh token 삭제
+        refreshTokenRepository.deleteByRefreshToken(refreshToken);
+
+        // TODO : 블랙 리스트 구현
+    }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/Impl/AuthServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/Impl/AuthServiceImpl.java
@@ -1,51 +1,39 @@
 package aurora.carevisionapiserver.global.auth.service.Impl;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
 import java.util.Optional;
 
 import jakarta.transaction.Transactional;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import aurora.carevisionapiserver.domain.admin.repository.AdminRepository;
 import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
-import aurora.carevisionapiserver.global.auth.converter.AuthConverter;
-import aurora.carevisionapiserver.global.auth.domain.RefreshToken;
 import aurora.carevisionapiserver.global.auth.domain.Role;
-import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.LoginResponse;
+import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.TokenResponse;
 import aurora.carevisionapiserver.global.auth.exception.AuthException;
 import aurora.carevisionapiserver.global.auth.repository.RefreshTokenRepository;
 import aurora.carevisionapiserver.global.auth.service.AuthService;
 import aurora.carevisionapiserver.global.auth.util.JWTUtil;
+import aurora.carevisionapiserver.global.auth.util.TokenGenerator;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
+import aurora.carevisionapiserver.global.util.validation.validator.RefreshTokenValidator;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
-    private static final String BEARER_PREFIX = "Bearer ";
-
     private final AuthenticationManager authenticationManager;
     private final JWTUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AdminRepository adminRepository;
     private final NurseRepository nurseRepository;
-
-    @Value("${jwt.refresh-expiration-time}")
-    private long refreshExpirationTime;
-
-    @Value("${jwt.access-expiration-time}")
-    private long accessExpirationTime;
+    private final RefreshTokenValidator refreshTokenValidator;
+    private final TokenGenerator tokenGenerator;
 
     @Override
     public Optional<Authentication> authenticate(String username, String password) {
@@ -59,40 +47,8 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    @Transactional
-    public String createAccessToken(String username, String role) {
-        return jwtUtil.createJwt("access", username, accessExpirationTime);
-    }
-
-    @Override
-    @Transactional
-    public String createRefreshToken(String username, String role) {
-        String refreshToken = jwtUtil.createJwt("refresh", username, refreshExpirationTime);
-        saveRefreshToken(username, refreshToken, refreshExpirationTime);
-        return refreshToken;
-    }
-
-    @Override
-    @Transactional
-    public void saveRefreshToken(String username, String refreshToken, long expiredMs) {
-        Date expiration = new Date(System.currentTimeMillis() + expiredMs);
-        RefreshToken newRefreshToken =
-                RefreshToken.builder()
-                        .username(username)
-                        .refreshToken(refreshToken)
-                        .expiration(expiration.toString())
-                        .build();
-        refreshTokenRepository.save(newRefreshToken);
-    }
-
-    @Override
-    public String getCurrentUserRole() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        Iterator<? extends GrantedAuthority> iter = authorities.iterator();
-        GrantedAuthority auth = iter.next();
-        return auth.getAuthority();
+    public TokenResponse generateTokens(String username) {
+        return tokenGenerator.generate(username);
     }
 
     @Override
@@ -124,41 +80,20 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public LoginResponse handleReissue(String refreshToken) {
-        if (refreshToken == null) {
-            throw new AuthException(ErrorStatus.REFRESH_TOKEN_NULL);
-        }
+    @Transactional
+    public TokenResponse handleReissue(String refreshToken) {
+        refreshTokenValidator.checkIfTokenNull(refreshToken);
+        refreshTokenValidator.validateToken(refreshToken);
+        refreshTokenValidator.validateTokenOwnerId(refreshToken);
+
+        // 이전 refresh token 삭제
+        refreshTokenRepository.deleteByRefreshToken(refreshToken);
 
         String username = jwtUtil.getId(refreshToken);
 
-        try {
-            refreshTokenRepository
-                    .findByUsername(username)
-                    .orElseThrow(() -> new AuthException(ErrorStatus.INVALID_REFRESH_TOKEN));
-        } catch (AuthException e) {
-            throw new AuthException(ErrorStatus.INVALID_CREDENTIALS);
-        }
-
-        // 이전 refresh token 삭제
-        refreshTokenRepository.deleteByUsername(username);
-
-        String newRefreshToken = jwtUtil.createJwt("refresh", username, refreshExpirationTime);
-        String newAccessToken = jwtUtil.createJwt("access", username, refreshExpirationTime);
-
-        // refresh token 업데이트
-        addRefreshToken(username, newRefreshToken, refreshExpirationTime);
-
-        return AuthConverter.toLoginResponse(newAccessToken, newRefreshToken);
+        return tokenGenerator.generate(username);
     }
 
-    public void addRefreshToken(String username, String refreshToken, long expiredMs) {
-        Date date = new Date(System.currentTimeMillis() + expiredMs);
-        RefreshToken newRefreshToken =
-                RefreshToken.builder()
-                        .username(username)
-                        .refreshToken(refreshToken)
-                        .expiration(date.toString())
-                        .build();
-        refreshTokenRepository.save(newRefreshToken);
-    }
+    @Override
+    public void logout(Long id, String refreshToken) {}
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/util/RefreshTokenValidator.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/util/RefreshTokenValidator.java
@@ -1,10 +1,9 @@
-package aurora.carevisionapiserver.global.util.validation.validator;
+package aurora.carevisionapiserver.global.auth.util;
 
 import org.springframework.stereotype.Component;
 
 import aurora.carevisionapiserver.global.auth.exception.AuthException;
 import aurora.carevisionapiserver.global.auth.repository.RefreshTokenRepository;
-import aurora.carevisionapiserver.global.auth.util.JWTUtil;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 
@@ -14,12 +13,6 @@ public class RefreshTokenValidator {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final JWTUtil jwtUtil;
-
-    public void checkIfTokenNull(String refreshToken) {
-        if (refreshToken == null) {
-            throw new AuthException(ErrorStatus.REFRESH_TOKEN_NULL);
-        }
-    }
 
     public void validateToken(String refreshToken) {
         jwtUtil.isValidToken(refreshToken);

--- a/src/main/java/aurora/carevisionapiserver/global/auth/util/TokenGenerator.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/util/TokenGenerator.java
@@ -1,0 +1,56 @@
+package aurora.carevisionapiserver.global.auth.util;
+
+import java.util.Date;
+
+import jakarta.transaction.Transactional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import aurora.carevisionapiserver.global.auth.converter.AuthConverter;
+import aurora.carevisionapiserver.global.auth.domain.RefreshToken;
+import aurora.carevisionapiserver.global.auth.dto.response.AuthResponse.TokenResponse;
+import aurora.carevisionapiserver.global.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TokenGenerator {
+    private final JWTUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${jwt.access-expiration-time}")
+    private long accessExpirationTime;
+
+    @Value("${jwt.refresh-expiration-time}")
+    private long refreshExpirationTime;
+
+    @Transactional
+    public TokenResponse generate(String username) {
+        String refreshToken = jwtUtil.createJwt("refresh", username, accessExpirationTime);
+        String accessToken = jwtUtil.createJwt("access", username, refreshExpirationTime);
+        saveRefreshToken(username, refreshToken, refreshExpirationTime);
+
+        return AuthConverter.toTokenResponse(accessToken, refreshToken);
+    }
+
+    private void saveRefreshToken(
+            String username, String refreshToken, long refreshExpirationTime) {
+        Date expiration = new Date(System.currentTimeMillis() + refreshExpirationTime);
+        RefreshToken newRefreshToken =
+                RefreshToken.builder()
+                        .username(username)
+                        .refreshToken(refreshToken)
+                        .expiration(expiration.toString())
+                        .build();
+        refreshTokenRepository.save(newRefreshToken);
+    }
+
+    public boolean isValidToken(String token) {
+        return jwtUtil.isValidToken(token);
+    }
+
+    public Long extractUsername(String token) {
+        return Long.valueOf(jwtUtil.getId(token));
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/global/security/handler/resolver/ExtractTokenArgumentResolver.java
+++ b/src/main/java/aurora/carevisionapiserver/global/security/handler/resolver/ExtractTokenArgumentResolver.java
@@ -38,7 +38,6 @@ public class ExtractTokenArgumentResolver implements HandlerMethodArgumentResolv
         }
 
         String token = authorizationHeader.substring(7);
-        jwtUtil.isValidToken(token);
         return token;
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/security/handler/resolver/ExtractTokenArgumentResolver.java
+++ b/src/main/java/aurora/carevisionapiserver/global/security/handler/resolver/ExtractTokenArgumentResolver.java
@@ -8,7 +8,6 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import aurora.carevisionapiserver.global.auth.exception.AuthException;
-import aurora.carevisionapiserver.global.auth.util.JWTUtil;
 import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
 import aurora.carevisionapiserver.global.security.handler.annotation.ExtractToken;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class ExtractTokenArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private final JWTUtil jwtUtil;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -37,7 +34,6 @@ public class ExtractTokenArgumentResolver implements HandlerMethodArgumentResolv
             throw new AuthException(ErrorStatus.UNAUTHORIZED_REQUEST);
         }
 
-        String token = authorizationHeader.substring(7);
-        return token;
+        return authorizationHeader.substring(7);
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/util/validation/validator/RefreshTokenValidator.java
+++ b/src/main/java/aurora/carevisionapiserver/global/util/validation/validator/RefreshTokenValidator.java
@@ -1,0 +1,34 @@
+package aurora.carevisionapiserver.global.util.validation.validator;
+
+import org.springframework.stereotype.Component;
+
+import aurora.carevisionapiserver.global.auth.exception.AuthException;
+import aurora.carevisionapiserver.global.auth.repository.RefreshTokenRepository;
+import aurora.carevisionapiserver.global.auth.util.JWTUtil;
+import aurora.carevisionapiserver.global.error.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class RefreshTokenValidator {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JWTUtil jwtUtil;
+
+    public void checkIfTokenNull(String refreshToken) {
+        if (refreshToken == null) {
+            throw new AuthException(ErrorStatus.REFRESH_TOKEN_NULL);
+        }
+    }
+
+    public void validateToken(String refreshToken) {
+        jwtUtil.isValidToken(refreshToken);
+    }
+
+    public void validateTokenOwnerId(String refreshToken) {
+        String username = jwtUtil.getId(refreshToken);
+        refreshTokenRepository
+                .findByUsername(username)
+                .orElseThrow(() -> new AuthException(ErrorStatus.INVALID_REFRESH_TOKEN));
+    }
+}

--- a/src/test/java/aurora/carevisionapiserver/controller/NurseAuthControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/controller/NurseAuthControllerTest.java
@@ -189,8 +189,8 @@ public class NurseAuthControllerTest {
 
         when(nurseRepository.findByUsername(username)).thenReturn(Optional.of(activeNurse));
 
-        when(authService.createAccessToken(username, role)).thenReturn(accessToken);
-        when(authService.createRefreshToken(username, role)).thenReturn(refreshToken);
+        when(authService.createAccessToken(username)).thenReturn(accessToken);
+        when(authService.createRefreshToken(username)).thenReturn(refreshToken);
         Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
         when(authService.createRefreshTokenCookie(refreshToken)).thenReturn(refreshTokenCookie);
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #114 

## 📌 개요
- 관리자 로그아웃 API `POST /api/admin/logout`, `POST /api/logout`을 구현했습니다.
- 기존 refresh 토큰 유효성 검사 로직을 RefreshTokenValidator로 분리하였습니다.
- 기존 access 토큰 및 refresh 토큰 생성 로직을 TokenGenerator 클래스의 generate 메서드로 분리하였습니다.

## 🔁 변경 사항
- 기존 `ExtractTokenArgumentResolve`r의 `resolveArgument`에서 jwt 토큰의 유효성을 검증하는 jwtUtil.validateToken() 메서드를 사용하였는데, refresh 토큰 유효성 검사는 모두 `RefreshTokenValidator`가 담당하도록 분리하고, `@ExtractToken` 애너테이션은 `Authorization` 헤더에서 `Bearer `를 파싱하는 기능만 담당하도록 수정하였습니다. ➡️ 책임이 많았던 😫 `handleReissue` 메서드를 간소화했습니다 : a40cfff7a2713134f344467e9030ae2bc645a33b
  - 이 과정에서 access 토큰과 refresh 토큰을 담는 DTO인 `LoginResponse`를 재사용이 용이하도록 이름을 `TokenResponse`로 변경했습니다.
- 관리자 로그아웃 API를 구현했습니다 : 7f98bcd3082c988cdb0f40d81b604dd5339cb043
- 간호사 로그아웃 API를 구현했습니다 : 71d7f1a60cdb97a65391cf187783ce96c7ac5fab

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
