### PR TITLE
[feat] 환자 코드를 통한 환자 조회 API

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/admin/domain/Admin.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/admin/domain/Admin.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 
 import aurora.carevisionapiserver.domain.hospital.domain.Department;
 import aurora.carevisionapiserver.global.auth.domain.Role;
+import aurora.carevisionapiserver.global.auth.domain.User;
 import aurora.carevisionapiserver.global.common.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "admin")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Admin extends BaseEntity {
+public class Admin extends BaseEntity implements User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/api/CameraController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/api/CameraController.java
@@ -1,22 +1,16 @@
 package aurora.carevisionapiserver.domain.camera.api;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import aurora.carevisionapiserver.domain.camera.converter.CameraConverter;
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse;
-import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
-import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingListResponse;
 import aurora.carevisionapiserver.domain.camera.service.CameraService;
-import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
-import aurora.carevisionapiserver.domain.patient.domain.Patient;
-import aurora.carevisionapiserver.domain.patient.service.PatientService;
+import aurora.carevisionapiserver.global.auth.domain.User;
 import aurora.carevisionapiserver.global.response.BaseResponse;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
 import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
@@ -27,43 +21,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "Camera 📷", description = "카메라 관련 API")
+@Tag(name = "Common - Camera 📷", description = "공통 - 카메라 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/cameras")
 public class CameraController {
     private final CameraService cameraService;
-    private final PatientService patientService;
-
-    @Operation(summary = "특정 환자 실시간 영상 스트리밍 관련 정보 조회 API", description = "환자의 스트리밍 관련 정보를 조회합니다_숙희")
-    @ApiResponses({
-        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-        @ApiResponse(responseCode = "CAMERA400", description = "NOT FOUND, 카메라를 찾을 수 없습니다.")
-    })
-    @GetMapping("/streaming/{patientId}")
-    public BaseResponse<StreamingInfoResponse> getStreamingInfo(
-            @PathVariable(name = "patientId") Long patientId) {
-        Patient patient = patientService.getPatient(patientId);
-        String cameraUrl = cameraService.getStreamingUrl(patient);
-        return BaseResponse.of(
-                SuccessStatus._OK, CameraConverter.toStreamingInfoResponse(cameraUrl, patient));
-    }
-
-    @Operation(
-            summary = "전체 담당 환자 실시간 영상 스트리밍 관련 정보 조회 API",
-            description = "담당하는 환자의 전체 스트리밍 관련 정보를 조회합니다_숙희")
-    @ApiResponses({
-        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-        @ApiResponse(responseCode = "CAMERA400", description = "NOT FOUND, 카메라를 찾을 수 없습니다.")
-    })
-    @GetMapping("/streaming")
-    public BaseResponse<StreamingListResponse> getStreamingInfoList(
-            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse) {
-        List<Patient> patients = patientService.getPatients(nurse);
-        Map<Patient, String> streamingInfo = cameraService.getStreamingInfo(patients);
-        return BaseResponse.of(
-                SuccessStatus._OK, CameraConverter.toStreamingListResponse(streamingInfo));
-    }
 
     @Operation(summary = "환자와 연결되지 않은 카메라 목록 조회 API", description = "환자와 연결되지 않은 카메라 목록 조회합니다_예림")
     @ApiResponses({
@@ -71,8 +34,8 @@ public class CameraController {
     })
     @GetMapping("/unlinked")
     public BaseResponse<CameraResponse.CameraInfoListResponse> getUnlinkedCameras(
-            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse) {
-        List<Camera> cameras = cameraService.getCameraInfoUnlinkedToPatient(nurse);
+            @Parameter(name = "user", hidden = true) @AuthUser User user) {
+        List<Camera> cameras = cameraService.getCameraInfoUnlinkedToPatient(user);
         return BaseResponse.of(
                 SuccessStatus._OK, CameraConverter.toCameraInfoListResponse(cameras));
     }

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraController.java
@@ -1,0 +1,65 @@
+package aurora.carevisionapiserver.domain.camera.api;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import aurora.carevisionapiserver.domain.camera.converter.CameraConverter;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingListResponse;
+import aurora.carevisionapiserver.domain.camera.service.CameraService;
+import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.domain.patient.service.PatientService;
+import aurora.carevisionapiserver.global.response.BaseResponse;
+import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
+import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Camera - Nurse 📷", description = "간호사 - 카메라 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class NurseCameraController {
+    private final CameraService cameraService;
+    private final PatientService patientService;
+
+    @Operation(summary = "특정 환자 실시간 영상 스트리밍 관련 정보 조회 API", description = "환자의 스트리밍 관련 정보를 조회합니다_숙희")
+    @ApiResponses({
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+        @ApiResponse(responseCode = "CAMERA400", description = "NOT FOUND, 카메라를 찾을 수 없습니다.")
+    })
+    @GetMapping("/streaming/{patientId}")
+    public BaseResponse<StreamingInfoResponse> getStreamingInfo(
+            @PathVariable(name = "patientId") Long patientId) {
+        Patient patient = patientService.getPatient(patientId);
+        String cameraUrl = cameraService.getStreamingUrl(patient);
+        return BaseResponse.of(
+                SuccessStatus._OK, CameraConverter.toStreamingInfoResponse(cameraUrl, patient));
+    }
+
+    @Operation(
+            summary = "전체 담당 환자 실시간 영상 스트리밍 관련 정보 조회 API",
+            description = "담당하는 환자의 전체 스트리밍 관련 정보를 조회합니다_숙희")
+    @ApiResponses({
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+        @ApiResponse(responseCode = "CAMERA400", description = "NOT FOUND, 카메라를 찾을 수 없습니다.")
+    })
+    @GetMapping("/streaming")
+    public BaseResponse<StreamingListResponse> getStreamingInfoList(
+            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse) {
+        List<Patient> patients = patientService.getPatients(nurse);
+        Map<Patient, String> streamingInfo = cameraService.getStreamingInfo(patients);
+        return BaseResponse.of(
+                SuccessStatus._OK, CameraConverter.toStreamingListResponse(streamingInfo));
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/CameraService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/CameraService.java
@@ -5,15 +5,15 @@ import java.util.Map;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
-import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.global.auth.domain.User;
 
 public interface CameraService {
     Camera getCamera(String cameraId);
 
     List<Camera> getAllCameraInfo(Admin admin);
 
-    List<Camera> getCameraInfoUnlinkedToPatient(Nurse nurse);
+    List<Camera> getCameraInfoUnlinkedToPatient(User user);
 
     void connectPatient(Camera cameraSelectRequest, Patient patient);
 

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
@@ -17,9 +17,9 @@ import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
 import aurora.carevisionapiserver.domain.camera.repository.CameraRepository;
 import aurora.carevisionapiserver.domain.camera.service.CameraService;
-import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.exception.CameraException;
+import aurora.carevisionapiserver.global.auth.domain.User;
 import aurora.carevisionapiserver.global.auth.service.S3Service;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
 import aurora.carevisionapiserver.global.util.UriFormatter;
@@ -42,9 +42,9 @@ public class CameraServiceImpl implements CameraService {
         return cameraRepository.findAllCamerasSortedByBed(admin.getDepartment().getId());
     }
 
-    public List<Camera> getCameraInfoUnlinkedToPatient(Nurse nurse) {
+    public List<Camera> getCameraInfoUnlinkedToPatient(User user) {
         return cameraRepository.findCamerasUnlinkedToPatientSortedByBed(
-                nurse.getDepartment().getId());
+                user.getDepartment().getId());
     }
 
     @Override

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/domain/Nurse.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/domain/Nurse.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.SQLRestriction;
 import aurora.carevisionapiserver.domain.hospital.domain.Department;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.global.auth.domain.Role;
+import aurora.carevisionapiserver.global.auth.domain.User;
 import aurora.carevisionapiserver.global.common.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,7 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE nurse SET deleted_at = NOW() WHERE nurse_id = ?")
-public class Nurse extends BaseEntity {
+public class Nurse extends BaseEntity implements User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/api/PatientController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/api/PatientController.java
@@ -1,0 +1,47 @@
+package aurora.carevisionapiserver.domain.patient.api;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import aurora.carevisionapiserver.domain.patient.converter.PatientConverter;
+import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.PatientCodeRequest;
+import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientNameResponse;
+import aurora.carevisionapiserver.domain.patient.service.PatientService;
+import aurora.carevisionapiserver.global.auth.domain.User;
+import aurora.carevisionapiserver.global.response.BaseResponse;
+import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
+import aurora.carevisionapiserver.global.security.handler.annotation.RefreshTokenApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Common-Patient 🤒", description = "공통 - 환자 등록 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/patients")
+public class PatientController {
+
+    private final PatientService patientService;
+
+    @Operation(
+            summary = "환자 번호를 통한 환자 조회 API",
+            description =
+                    "환자 코드를 입력하여 환자명을 조회합니다. 환자 코드를 보내주면 랜덤으로 이름을 생성합니다. 환자 코드는 민감한 개인 정보를 포함할 수 있으므로 POST 요청을 통해 전송됩니다._예림")
+    @ApiResponses({
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @RefreshTokenApiResponse
+    @PostMapping("/name")
+    public BaseResponse<PatientNameResponse> getPatientNameByCode(
+            @Parameter(name = "user", hidden = true) @AuthUser User user,
+            @RequestBody PatientCodeRequest patientCodeRequest) {
+        String patientCode = patientCodeRequest.getCode();
+        String patientName = patientService.getPatientNameByCode(patientCode);
+        return BaseResponse.onSuccess(PatientConverter.toPatientNameResponse(patientName));
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/converter/PatientConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/converter/PatientConverter.java
@@ -9,6 +9,7 @@ import aurora.carevisionapiserver.domain.bed.domain.Bed;
 import aurora.carevisionapiserver.domain.hospital.domain.Department;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.PatientCreateRequest;
+import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientNameResponse;
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientProfileListResponse;
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientProfileResponse;
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
@@ -65,5 +66,9 @@ public class PatientConverter {
                         .build();
         bed.registerPatient(patient);
         return patient;
+    }
+
+    public static PatientNameResponse toPatientNameResponse(String name) {
+        return PatientNameResponse.builder().name(name).build();
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/dto/request/PatientRequest.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/dto/request/PatientRequest.java
@@ -35,4 +35,12 @@ public class PatientRequest {
     public static class PatientSelectRequest {
         private Long patientId;
     }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PatientCodeRequest {
+        private String code;
+    }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/dto/response/PatientResponse.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/dto/response/PatientResponse.java
@@ -42,4 +42,10 @@ public class PatientResponse {
         private List<PatientProfileResponse> patients;
         private int count;
     }
+
+    @Builder
+    @Getter
+    public static class PatientNameResponse {
+        private String name;
+    }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -21,6 +21,7 @@ import aurora.carevisionapiserver.domain.patient.exception.PatientException;
 import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
+import aurora.carevisionapiserver.global.util.PatientNameUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -111,6 +112,11 @@ public class PatientServiceImpl implements PatientService {
     @Override
     public List<Patient> getUnlinkedPatients(Nurse nurse) {
         return patientRepository.findUnlinkedPatientsByNurse(nurse);
+    }
+
+    @Override
+    public String getPatientNameByCode(String patientCode) {
+        return PatientNameUtil.generateRandomName(patientCode);
     }
 
     public Patient getPatient(Long patientId) {

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/PatientService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/PatientService.java
@@ -30,4 +30,6 @@ public interface PatientService {
             Admin admin);
 
     List<Patient> getUnlinkedPatients(Nurse nurse);
+
+    String getPatientNameByCode(String patientCode);
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/domain/User.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/domain/User.java
@@ -1,0 +1,7 @@
+package aurora.carevisionapiserver.global.auth.domain;
+
+import aurora.carevisionapiserver.domain.hospital.domain.Department;
+
+public interface User {
+    Department getDepartment();
+}

--- a/src/main/java/aurora/carevisionapiserver/global/config/SecurityConfig.java
+++ b/src/main/java/aurora/carevisionapiserver/global/config/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
                         authorize
                                 .requestMatchers(allowedUrls)
                                 .permitAll()
-                                .requestMatchers("/api/cameras/unlinked")
+                                .requestMatchers("/api/cameras/unlinked", "/api/patients/name")
                                 .hasAnyRole("ADMIN", "NURSE")
                                 .requestMatchers("/api/admin/**")
                                 .hasRole("ADMIN")

--- a/src/main/java/aurora/carevisionapiserver/global/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/aurora/carevisionapiserver/global/security/handler/resolver/AuthUserArgumentResolver.java
@@ -14,6 +14,7 @@ import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.admin.service.AdminService;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.service.NurseService;
+import aurora.carevisionapiserver.global.auth.domain.User;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
 import aurora.carevisionapiserver.global.response.exception.GeneralException;
 import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
@@ -29,7 +30,8 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return (parameter.getParameterType().equals(Admin.class)
-                        || parameter.getParameterType().equals(Nurse.class))
+                        || parameter.getParameterType().equals(Nurse.class)
+                        || parameter.getParameterType().equals(User.class))
                 && parameter.hasParameterAnnotation(AuthUser.class);
     }
 

--- a/src/main/java/aurora/carevisionapiserver/global/util/PatientNameUtil.java
+++ b/src/main/java/aurora/carevisionapiserver/global/util/PatientNameUtil.java
@@ -1,0 +1,27 @@
+package aurora.carevisionapiserver.global.util;
+
+import java.util.Random;
+
+public class PatientNameUtil {
+    private static final String[] FIRST_NAMES = {
+        "김", "이", "박", "최", "정", "강", "조", "윤", "장", "임",
+        "한", "오", "서", "신", "권", "황", "안", "송", "류", "홍",
+        "구", "남", "도", "심", "백", "방", "원", "변", "현", "손"
+    };
+
+    private static final String[] LAST_NAMES = {
+        "민준", "서준", "도윤", "예준", "시우", "주원", "하준", "지호", "준서", "준우",
+        "현우", "지훈", "건우", "우진", "선우", "민호", "현준", "지환", "동현", "민규",
+        "성현", "승현", "재윤", "은우", "지우", "현성", "정우", "승준", "시현", "민성",
+        "태현", "준혁", "재현", "성민", "지훈", "동건", "준영", "민재", "시윤", "현진"
+    };
+
+    public static String generateRandomName(String seed) {
+        Random random = new Random(seed.hashCode());
+
+        String firstName = FIRST_NAMES[random.nextInt(FIRST_NAMES.length)];
+        String lastName = LAST_NAMES[random.nextInt(LAST_NAMES.length)];
+
+        return firstName + lastName;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,7 +17,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update
         default_batch_fetch_size: 1000
 
   data:

--- a/src/test/java/aurora/carevisionapiserver/controller/AdminNurseCameraControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/controller/AdminNurseCameraControllerTest.java
@@ -24,7 +24,7 @@ import aurora.carevisionapiserver.domain.camera.service.CameraService;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 
 @WebMvcTest(AdminCameraController.class)
-class AdminCameraControllerTest {
+class AdminNurseCameraControllerTest {
 
     @MockBean private CameraService cameraService;
     @Autowired private MockMvc mockMvc;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #154

## 📌 개요
- 환자 코드를 통한 환자 조회 API `POST /api/patients/name`을 구현하였습니다.
- 간호사와 관리자가 공통적으로 사용할 수 있는 API는 따로 Tag를 분리하고 Admin과 Nurse의 공통 인터페이스인 User를 정의했습니다.

## 🔁 변경 사항
- **환자 코드를 통한 환자 조회 API `POST /api/patients/name` 구현** : 388f44677b324141c18b399d84297432c7190bc0
  - 조회이므로 GET 메서드가 적합하나 환자 코드는 민감한 개인 정보를 포함할 수 있으므로 POST 요청으로 구현했습니다.
    > 현재 민감한 정보는 없지만.. 😅
  - 또한 환자 코드는 각 병원에서 자체 생성하는 것이기 때문에 환자 코드로 환자명을 조회하는 게 불가능하지만, 시간 관계상 랜덤 환자명을 리턴하도록 구현했습니다. (랜덤 환자명 생성은 `PatientNameUtils` 클래스에서 담당합니다.

- **관리자와 간호사가 공통으로 사용하는 API 분리** : a93ef6b6ab10197ffe773629529db64ff3e1b242, 298f015190c4f0ec3dc214c450911753608fbe9f
  - 연결되지 않은 카메라 조회 `GET /api/cameras/unlinked`와 POST /api/patients/name`는 관리자와 간호사 모두 사용이 가능해야 합니다.
  - 따라서 SecurityConfig를 수정해주고
  - Admin과 Nurse의 공통 인터페이스인 User를 정의하였습니다.
  - AuthUserResolver의 supportsParameter에서 다음과 같이 User 클래스도 체크하도록 구현해주었습니다.
  ```java
   @Override
    public boolean supportsParameter(MethodParameter parameter) {
        return (parameter.getParameterType().equals(Admin.class)
                        || parameter.getParameterType().equals(Nurse.class)
                        || parameter.getParameterType().equals(User.class)) // User.class도 체크
                && parameter.hasParameterAnnotation(AuthUser.class);
    }
  ```
    - 이 User 인터페이스를 정의함으로써 똑같은 기능을 하지만 Nurse와 Admin가 다른 도메인이었기 때문에 다르게 다르게 오버로딩했던 메서드를 통합하기가 쉬워질 것 같습니다!! 나중에 수정하겠습니다!!
 

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
