### PR TITLE
[refactor] 썸네일 요청시 최근에 저장된 이미지 응답하는 방식으로 수정 및 스케쥴러 적용해 업데이트, 삭제 기능 구현

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
@@ -1,17 +1,13 @@
 package aurora.carevisionapiserver.domain.camera.service.Impl;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import jakarta.transaction.Transactional;
 
-import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
@@ -22,7 +18,6 @@ import aurora.carevisionapiserver.domain.patient.exception.CameraException;
 import aurora.carevisionapiserver.global.auth.domain.User;
 import aurora.carevisionapiserver.global.auth.service.S3Service;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
-import aurora.carevisionapiserver.global.util.UriFormatter;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -30,9 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class CameraServiceImpl implements CameraService {
     private static final int CAMERA_IP_INDEX = 0;
     private static final int CAMERA_PW_INDEX = 1;
-    private static final String S3_KEY = "s3_url";
     private final S3Service s3Service;
-    private final UriFormatter uriFormatter;
 
     @Value("${camera.streaming.url}")
     String urlFormat;
@@ -74,22 +67,8 @@ public class CameraServiceImpl implements CameraService {
     }
 
     private String getThumbnail(Patient patient) {
-        String rtspUrl = getStreamingUrl(patient);
         Long patientId = patient.getId();
-        URI requestUrl = uriFormatter.getThumbnailUrl(rtspUrl, patientId.toString());
-        if (requestUrl == null) {
-            return s3Service.getRecentImage(patientId);
-        }
-
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<String> response = restTemplate.getForEntity(requestUrl, String.class);
-
-        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-            JSONObject jsonResponse = new JSONObject(response.getBody());
-            return jsonResponse.getString(S3_KEY);
-        } else {
-            return s3Service.getRecentImage(patientId);
-        }
+        return s3Service.getRecentImage(patientId);
     }
 
     private List<String> getCameraInfoLinkedToPatient(Patient patient) {

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/RtspServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/RtspServiceImpl.java
@@ -1,0 +1,35 @@
+package aurora.carevisionapiserver.domain.camera.service.Impl;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import aurora.carevisionapiserver.domain.camera.service.CameraService;
+import aurora.carevisionapiserver.domain.camera.service.RtspService;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.global.util.UriFormatter;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RtspServiceImpl implements RtspService {
+    private final UriFormatter uriFormatter;
+    private final CameraService cameraService;
+
+    @Override
+    public Boolean requestThumbnailUrl(Patient patient) {
+        String rtspUrl = cameraService.getStreamingUrl(patient);
+        Long patientId = patient.getId();
+        URI requestUrl = uriFormatter.requestThumbnailUrl(rtspUrl, patientId.toString());
+        if (requestUrl == null) {
+            return false;
+        }
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.getForEntity(requestUrl, String.class);
+
+        return response.getStatusCode().is2xxSuccessful() && response.getBody() != null;
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/RtspService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/RtspService.java
@@ -1,0 +1,7 @@
+package aurora.carevisionapiserver.domain.camera.service;
+
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+
+public interface RtspService {
+    Boolean requestThumbnailUrl(Patient patient);
+}

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/S3Service.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/S3Service.java
@@ -45,9 +45,6 @@ public class S3Service {
         Date thresholdDate =
                 new Date(System.currentTimeMillis() - (daysOld * 24L * 60 * 60 * 1000));
 
-        if (objectSummaries.size() <= 1) {
-            return;
-        }
         for (S3ObjectSummary summary : objectSummaries) {
             if (summary.getLastModified().before(thresholdDate)) {
                 String objectKey = summary.getKey();

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/S3Service.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/S3Service.java
@@ -2,6 +2,7 @@ package aurora.carevisionapiserver.global.auth.service;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -14,19 +15,52 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 import aurora.carevisionapiserver.global.exception.S3Exception;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
+import aurora.carevisionapiserver.global.util.UriFormatter;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class S3Service {
-    private final AmazonS3 amazonS3;
+    private static final String THUMBNAIL_PATH = "thumbnail/";
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    private final AmazonS3 amazonS3;
+    private final UriFormatter uriFormatter;
+
     public String getRecentImage(Long patientId) {
+        List<S3ObjectSummary> objectSummaries = getS3ObjectsByPrefix(patientId);
+
+        S3ObjectSummary mostRecentObject =
+                Collections.max(
+                        objectSummaries, Comparator.comparing(S3ObjectSummary::getLastModified));
+
+        return uriFormatter.getThumbnailUrl(bucket, mostRecentObject.getKey());
+    }
+
+    public void deleteOldThumbnail(Long patientId, int daysOld) {
+        List<S3ObjectSummary> objectSummaries = getS3ObjectsByPrefix(patientId);
+
+        Date thresholdDate =
+                new Date(System.currentTimeMillis() - (daysOld * 24L * 60 * 60 * 1000));
+
+        if (objectSummaries.size() <= 1) {
+            return;
+        }
+        for (S3ObjectSummary summary : objectSummaries) {
+            if (summary.getLastModified().before(thresholdDate)) {
+                String objectKey = summary.getKey();
+                amazonS3.deleteObject(bucket, objectKey);
+            }
+        }
+    }
+
+    private List<S3ObjectSummary> getS3ObjectsByPrefix(Long patientId) {
         ListObjectsV2Request request =
-                new ListObjectsV2Request().withBucketName(bucket).withPrefix(patientId.toString());
+                new ListObjectsV2Request()
+                        .withBucketName(bucket)
+                        .withPrefix(THUMBNAIL_PATH + patientId.toString());
 
         ListObjectsV2Result result = amazonS3.listObjectsV2(request);
         List<S3ObjectSummary> objectSummaries = result.getObjectSummaries();
@@ -34,11 +68,6 @@ public class S3Service {
         if (objectSummaries.isEmpty()) {
             throw new S3Exception(ErrorStatus.EMPTY_S3_IMAGE);
         }
-
-        S3ObjectSummary mostRecentObject =
-                Collections.max(
-                        objectSummaries, Comparator.comparing(S3ObjectSummary::getLastModified));
-
-        return mostRecentObject.getKey();
+        return objectSummaries;
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/config/SchedulerConfig.java
+++ b/src/main/java/aurora/carevisionapiserver/global/config/SchedulerConfig.java
@@ -1,0 +1,52 @@
+package aurora.carevisionapiserver.global.config;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import aurora.carevisionapiserver.domain.camera.service.RtspService;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
+import aurora.carevisionapiserver.global.auth.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class SchedulerConfig {
+    private static final int DAYS_OLD = 1;
+    private final PatientRepository patientRepository;
+    private final RtspService rtspService;
+    private final S3Service s3Service;
+
+    @Scheduled(cron = "0 */10 * * * *") // 매 10분마다 수행
+    private void updateThumbnail() {
+        log.info("썸네일 업데이트 시작");
+
+        List<Patient> patients = patientRepository.findAll();
+
+        for (Patient patient : patients) {
+            Boolean response = rtspService.requestThumbnailUrl(patient);
+            log.info("환자 아이디: " + patient.getId() + " 썸네일 업데이트 결과: " + response);
+        }
+
+        log.info("썸네일 업데이트 끝");
+    }
+
+    @Scheduled(cron = "0 0 9,18 * * *") //  오전 9시와 오후 6시에 수행
+    private void deleteOldThumbnail() {
+        log.info("오래된 썸네일 삭제 시작");
+
+        List<Patient> patients = patientRepository.findAll();
+
+        for (Patient patient : patients) {
+            s3Service.deleteOldThumbnail(patient.getId(), DAYS_OLD);
+        }
+
+        log.info("오래된 썸네일 삭제 끝");
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/global/util/UriFormatter.java
+++ b/src/main/java/aurora/carevisionapiserver/global/util/UriFormatter.java
@@ -20,4 +20,8 @@ public class UriFormatter {
             return null;
         }
     }
+
+    public String getThumbnailUrl(String bucket, String key) {
+        return String.format("https://%s.s3.amazonaws.com/%s", bucket, key);
+    }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/util/UriFormatter.java
+++ b/src/main/java/aurora/carevisionapiserver/global/util/UriFormatter.java
@@ -12,7 +12,7 @@ public class UriFormatter {
     @Value("${camera.thumbnail.url}")
     private String thumbnailUrl;
 
-    public URI getThumbnailUrl(String rtspUrl, String patientId) {
+    public URI requestThumbnailUrl(String rtspUrl, String patientId) {
         String encodedRtspUrl = URLEncoder.encode(rtspUrl, StandardCharsets.UTF_8);
         try {
             return new URI(thumbnailUrl + "?url=" + encodedRtspUrl + "&patient_id=" + patientId);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #160

## 📌 개요기
기존 스트리밍 정보를 조회하면 썸네일 정보를 가져오기 위해서
spring에서 fastapi로 rtsp 링크로 프레임 캡쳐 요청을 보내고, fastapi에서 s3에 데이터를 저장해 그 url을 다시 spring으로 응답해주면 그것을 다시 클라이언트로 리턴하는 형식이었습니다
적기만 해도 엄청 복잡하네요...

응답시간이 너무 길어져서 수정을 하였습니다. 
어떻게 바꾸었냐면
1. spring에서는 s3의 최신 저장된 사진 데이터를 불러와 응답합니다. 
2. 스케쥴러를 돌려서 10분마다 썸네일 데이터를 저장합니다.(10분이 아니어도 되는데 일단 너무 주기적으로 저장할 필요는 없을 것 같아서 넉넉하게 10분으로 설정해두었습니다) 
3. 10분마다 데이터가 쌓이면 너무 많아질 것 같아 하루에 2번(오전 9시와 오후 6시-> 이 또한 적절하게 수정해도 되는데 일단 2번은 지워야할거 같아서 2번으로 설정해두었습니다.) 삭제 요청을 보냅니다.

페이지 처리를 해야하나 했는데, 위 방법으로 수정하고 나서 응답 시간이 정말 눈에 띄게 줄어들어서 일단은 이 정도 처리만 해도 될 것 같습니다!!

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
