### PR TITLE
[fix] 환자와 카메라 연결시 중복 외래키 설정 문제 해결

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/bed/repository/BedRepository.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/bed/repository/BedRepository.java
@@ -1,0 +1,12 @@
+package aurora.carevisionapiserver.domain.bed.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+
+public interface BedRepository extends JpaRepository<Bed, Long> {
+    Optional<Bed> findByBedNumberAndInpatientWardNumberAndPatientRoomNumber(
+            Long bedNumber, Long inpatientWardNumber, Long patientRoomNumber);
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/bed/service/BedService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/bed/service/BedService.java
@@ -1,0 +1,8 @@
+package aurora.carevisionapiserver.domain.bed.service;
+
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+import aurora.carevisionapiserver.domain.bed.dto.BedRequest.BedCreateRequest;
+
+public interface BedService {
+    Bed findBed(BedCreateRequest bedCreateRequest);
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/bed/service/impl/BedServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/bed/service/impl/BedServiceImpl.java
@@ -1,0 +1,27 @@
+package aurora.carevisionapiserver.domain.bed.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+import aurora.carevisionapiserver.domain.bed.dto.BedRequest;
+import aurora.carevisionapiserver.domain.bed.exception.BedException;
+import aurora.carevisionapiserver.domain.bed.repository.BedRepository;
+import aurora.carevisionapiserver.domain.bed.service.BedService;
+import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BedServiceImpl implements BedService {
+    private final BedRepository bedRepository;
+
+    @Override
+    public Bed findBed(BedRequest.BedCreateRequest bed) {
+        return bedRepository
+                .findByBedNumberAndInpatientWardNumberAndPatientRoomNumber(
+                        bed.getBedNumber(),
+                        bed.getInpatientWardNumber(),
+                        bed.getPatientRoomNumber())
+                .orElseThrow(() -> new BedException(ErrorStatus.BED_NOT_FOUND));
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/CameraService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/CameraService.java
@@ -9,13 +9,9 @@ import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.global.auth.domain.User;
 
 public interface CameraService {
-    Camera getCamera(String cameraId);
-
     List<Camera> getAllCameraInfo(Admin admin);
 
     List<Camera> getCameraInfoUnlinkedToPatient(User user);
-
-    void connectPatient(Camera cameraSelectRequest, Patient patient);
 
     String getStreamingUrl(Patient patient);
 

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import jakarta.transaction.Transactional;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -39,19 +37,6 @@ public class CameraServiceImpl implements CameraService {
     public List<Camera> getCameraInfoUnlinkedToPatient(User user) {
         return cameraRepository.findCamerasUnlinkedToPatientSortedByBed(
                 user.getDepartment().getId());
-    }
-
-    @Override
-    @Transactional
-    public void connectPatient(Camera camera, Patient patient) {
-        patient.getBed().registerCamera(camera);
-    }
-
-    @Override
-    public Camera getCamera(String cameraId) {
-        return cameraRepository
-                .findById(cameraId)
-                .orElseThrow(() -> new CameraException(ErrorStatus.CAMERA_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/converter/PatientConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/converter/PatientConverter.java
@@ -55,8 +55,10 @@ public class PatientConverter {
     }
 
     public static Patient toPatient(
-            PatientCreateRequest patientCreateRequest, Department department) {
-        Bed bed = BedConverter.toBed(patientCreateRequest.getBed(), department);
+            PatientCreateRequest patientCreateRequest, Bed bed, Department department) {
+        if (bed == null) {
+            bed = BedConverter.toBed(patientCreateRequest.getBed(), department);
+        }
         Patient patient =
                 Patient.builder()
                         .name(patientCreateRequest.getName())

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -99,7 +99,7 @@ public class PatientServiceImpl implements PatientService {
 
     private Patient createPatient(
             PatientCreateRequest patientCreateRequest, Department department) {
-        String patientCode = patientCreateRequest.getCode();
+        patientValidator.validatePatientCode(patientCreateRequest.getCode());
 
         if (patientRepository.existsByCode(patientCode)) {
             throw new PatientException(ErrorStatus.PATIENT_DUPLICATED);

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Service;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.admin.service.AdminService;
-import aurora.carevisionapiserver.domain.camera.domain.Camera;
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+import aurora.carevisionapiserver.domain.bed.service.BedService;
 import aurora.carevisionapiserver.domain.camera.dto.request.CameraRequest.CameraSelectRequest;
-import aurora.carevisionapiserver.domain.camera.service.CameraService;
 import aurora.carevisionapiserver.domain.hospital.domain.Department;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.service.NurseService;
@@ -22,15 +22,17 @@ import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
 import aurora.carevisionapiserver.global.util.PatientNameUtil;
+import aurora.carevisionapiserver.global.util.PatientValidator;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class PatientServiceImpl implements PatientService {
     private final PatientRepository patientRepository;
+    private final BedService bedService;
     private final AdminService adminService;
     private final NurseService nurseService;
-    private final CameraService cameraService;
+    private final PatientValidator patientValidator;
 
     @Override
     public List<Patient> searchPatient(String patientName) {
@@ -72,7 +74,7 @@ public class PatientServiceImpl implements PatientService {
             CameraSelectRequest cameraSelectRequest,
             Nurse nurse) {
         Patient patient = createPatient(patientCreateRequest, nurse.getDepartment());
-        connectCameraAndNurseToPatient(cameraSelectRequest, patient, nurse);
+        connectNurseToPatient(patient, nurse);
     }
 
     @Override
@@ -81,31 +83,19 @@ public class PatientServiceImpl implements PatientService {
             PatientCreateRequest patientCreateRequest,
             CameraSelectRequest cameraSelectRequest,
             Admin admin) {
-        Patient patient = createPatient(patientCreateRequest, admin.getDepartment());
-        connectCameraToPatient(cameraSelectRequest, patient);
+        createPatient(patientCreateRequest, admin.getDepartment());
     }
 
-    private void connectCameraAndNurseToPatient(
-            CameraSelectRequest cameraSelectRequest, Patient patient, Nurse nurse) {
-        Camera camera = cameraService.getCamera(cameraSelectRequest.getId());
-        cameraService.connectPatient(camera, patient);
+    private void connectNurseToPatient(Patient patient, Nurse nurse) {
         nurseService.connectPatient(nurse, patient);
-    }
-
-    private void connectCameraToPatient(CameraSelectRequest cameraSelectRequest, Patient patient) {
-        Camera camera = cameraService.getCamera(cameraSelectRequest.getId());
-        cameraService.connectPatient(camera, patient);
     }
 
     private Patient createPatient(
             PatientCreateRequest patientCreateRequest, Department department) {
         patientValidator.validatePatientCode(patientCreateRequest.getCode());
 
-        if (patientRepository.existsByCode(patientCode)) {
-            throw new PatientException(ErrorStatus.PATIENT_DUPLICATED);
-        }
-
-        Patient patient = PatientConverter.toPatient(patientCreateRequest, department);
+        Bed bed = bedService.findBed(patientCreateRequest.getBed());
+        Patient patient = PatientConverter.toPatient(patientCreateRequest, bed, department);
         return patientRepository.save(patient);
     }
 

--- a/src/main/java/aurora/carevisionapiserver/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/aurora/carevisionapiserver/global/response/code/status/ErrorStatus.java
@@ -53,7 +53,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // Bed
     INVALID_BED_INFO(
             HttpStatus.BAD_REQUEST, "BED400", "잘못된 형식의 베드 정보입니다. '동 호 번' 또는 '호 번' 순서로 작성해 주세요."),
-
+    BED_NOT_FOUND(HttpStatus.NOT_FOUND, "BED401", "베드를 찾을 수 없습니다."),
     // fcm
     CLIENT_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "FCM400", "token이 만료되었습니다."),
     CLIENT_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "FCM401", "token을 찾을 수 없습니다."),

--- a/src/main/java/aurora/carevisionapiserver/global/util/PatientValidator.java
+++ b/src/main/java/aurora/carevisionapiserver/global/util/PatientValidator.java
@@ -1,0 +1,20 @@
+package aurora.carevisionapiserver.global.util;
+
+import org.springframework.stereotype.Component;
+
+import aurora.carevisionapiserver.domain.patient.exception.PatientException;
+import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
+import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PatientValidator {
+    private final PatientRepository patientRepository;
+
+    public void validatePatientCode(String code) {
+        if (patientRepository.existsByCode(code)) {
+            throw new PatientException(ErrorStatus.PATIENT_DUPLICATED);
+        }
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #164

## 📌 개요
- 기존 등록된 bed의 camera외래키를 중복해서 사용하려고 해서 문제가 생겼었는데, 해결하기 위해서 환자를 생성할 때, converter에 bed정보를 같이 넘겨주도록 설정했습니다. 
- bed정보는 입력받은 bed info를 기준으로 레포지토리에서 검색하며, 해당하는 bed가 있을 경우 그 bed를 찾아옵니다. 
- 이렇게 되면 기존 connectCameraToPatient 메서드는 사용될 필요가 없으므로 로직에서 제거했습니다. 
- 현재 admin과 nurse가 동일한 로직으로 구현되어있어서, 두 부분 다 수정했습니다. 

+) 2b79e9405c5285a8c78ff3657a3c3c0911fcfbbf 사용되지 않는 코드 삭제했습니다. 

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
