### PR TITLE
[feat] 알람 조회 시 firestore의 read값 업데이트 및 알림 전용 스트리밍 조회 API 구현

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/admin/api/AdminAuthController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/admin/api/AdminAuthController.java
@@ -1,5 +1,7 @@
 package aurora.carevisionapiserver.domain.admin.api;
 
+import java.util.HashMap;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -114,10 +116,10 @@ public class AdminAuthController {
         @ApiResponse(responseCode = "AUTH404", description = "인증에 실패했습니다.")
     })
     @PostMapping("/logout")
-    public BaseResponse<TokenResponse> logout(
+    public BaseResponse<Object> logout(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
             @RequestHeader("refreshToken") @ExtractToken String refreshToken) {
         authService.logout(admin.getId(), refreshToken);
-        return BaseResponse.of(SuccessStatus._NO_CONTENT, null);
+        return BaseResponse.of(SuccessStatus._NO_CONTENT, new HashMap<>());
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/AdminNurseController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/AdminNurseController.java
@@ -1,5 +1,6 @@
 package aurora.carevisionapiserver.domain.nurse.api;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -81,11 +82,11 @@ public class AdminNurseController {
     })
     @RefreshTokenApiResponse
     @PostMapping("/nurses/requests/{nurseId}")
-    public BaseResponse<Void> acceptNurseRegisterRequest(
+    public BaseResponse<Object> acceptNurseRegisterRequest(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
             @PathVariable Long nurseId) {
         nurseService.activateNurse(nurseId);
-        return BaseResponse.of(SuccessStatus.ACCEPTED, null);
+        return BaseResponse.of(SuccessStatus.ACCEPTED, new HashMap<>());
     }
 
     @Operation(summary = "간호사 요청 거부 API", description = "간호사 등록 요청을 거부합니다_예림")
@@ -96,11 +97,11 @@ public class AdminNurseController {
     @RefreshTokenApiResponse
     @DeleteMapping("/nurses/requests/{nurseId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public BaseResponse<Void> deleteInactiveNurse(
+    public BaseResponse<Object> deleteInactiveNurse(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
             @PathVariable Long nurseId) {
         nurseService.deleteInactiveNurse(nurseId);
-        return BaseResponse.of(SuccessStatus._NO_CONTENT, null);
+        return BaseResponse.of(SuccessStatus._NO_CONTENT, new HashMap<>());
     }
 
     @Operation(summary = "간호사 등록 요청 수 조회 API", description = "간호사 등록 요청 수를 조회합니다_예림")
@@ -122,10 +123,10 @@ public class AdminNurseController {
     })
     @RefreshTokenApiResponse
     @DeleteMapping("/nurses/{nurseId}")
-    public BaseResponse<Void> deleteActiveNurse(
+    public BaseResponse<Object> deleteActiveNurse(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
             @PathVariable Long nurseId) {
         nurseService.deleteActiveNurse(nurseId);
-        return BaseResponse.of(SuccessStatus._NO_CONTENT, null);
+        return BaseResponse.of(SuccessStatus._NO_CONTENT, new HashMap<>());
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
@@ -10,9 +10,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import aurora.carevisionapiserver.domain.camera.dto.request.CameraRequest.CameraSelectRequest;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
 import aurora.carevisionapiserver.domain.nurse.converter.NurseConverter;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.dto.request.NurseRequest.NurseAcceptanceRetryRequest;
@@ -150,6 +152,16 @@ public class NurseController {
     public BaseResponse<AlarmInfoListResponse> getAlarmsInfo(
             @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse) {
         return BaseResponse.of(SuccessStatus._OK, fcmService.getAlarmsInfo(nurse));
+    }
+
+    @Operation(summary = "간호사의 알람 상세 조회 API", description = "이상행동 감지 알람을 조회합니다._숙희")
+    @ApiResponses({@ApiResponse(responseCode = "COMMON200", description = "OK, 성공")})
+    @RefreshTokenApiResponse
+    @GetMapping("/alarm")
+    public BaseResponse<StreamingInfoResponse> getAlarmsInfo(
+            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
+            @RequestParam(name = "documentId") String documentId) {
+        return BaseResponse.of(SuccessStatus._OK, fcmService.getAlarmInfo(nurse, documentId));
     }
 
     @Operation(summary = "간호사의 수락 재요청 API", description = "간호사가 수락을 재요청합니다_예림")

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
@@ -1,5 +1,6 @@
 package aurora.carevisionapiserver.domain.nurse.api;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.springframework.validation.annotation.Validated;
@@ -84,12 +85,12 @@ public class NurseController {
     })
     @RefreshTokenApiResponse
     @PatchMapping("/patients")
-    public BaseResponse<String> connectPatient(
+    public BaseResponse<Object> connectPatient(
             @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
             @RequestBody PatientSelectRequest patientSelectRequest) {
         Patient patient = patientService.getPatient(patientSelectRequest.getPatientId());
         nurseService.connectPatient(nurse, patient);
-        return BaseResponse.of(SuccessStatus._CREATED, null);
+        return BaseResponse.of(SuccessStatus._CREATED, new HashMap<>());
     }
 
     @Operation(
@@ -100,7 +101,7 @@ public class NurseController {
     })
     @RefreshTokenApiResponse
     @PostMapping("/patients")
-    public BaseResponse<Void> createPatient(
+    public BaseResponse<Object> createPatient(
             @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
             @RequestBody PatientRegisterRequest patientRegisterRequest) {
         PatientCreateRequest patientCreateRequest = patientRegisterRequest.getPatient();
@@ -108,7 +109,7 @@ public class NurseController {
 
         patientService.createAndConnectPatient(patientCreateRequest, cameraSelectRequest, nurse);
 
-        return BaseResponse.of(SuccessStatus._CREATED, null);
+        return BaseResponse.of(SuccessStatus._CREATED, new HashMap<>());
     }
 
     @Operation(summary = "담당 환자 퇴원 API", description = "환자를 퇴원합니다_예림")
@@ -118,11 +119,11 @@ public class NurseController {
     })
     @RefreshTokenApiResponse
     @DeleteMapping("patients/{patientId}")
-    public BaseResponse<Void> deletePatient(
+    public BaseResponse<Object> deletePatient(
             @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
             @PathVariable Long patientId) {
         patientService.deletePatient(patientId);
-        return BaseResponse.of(SuccessStatus._NO_CONTENT, null);
+        return BaseResponse.of(SuccessStatus._NO_CONTENT, new HashMap<>());
     }
 
     @Operation(
@@ -171,9 +172,9 @@ public class NurseController {
     })
     @RefreshTokenApiResponse
     @PostMapping("/requests/retry")
-    public BaseResponse<Void> retryNurseAcceptanceRequest(
+    public BaseResponse<Object> retryNurseAcceptanceRequest(
             @RequestBody NurseAcceptanceRetryRequest nurseAcceptanceRetryRequest) {
         nurseService.retryAcceptanceRequest(nurseAcceptanceRetryRequest.getUsername());
-        return BaseResponse.of(SuccessStatus.NURSE_REQUEST_RETRIED, null);
+        return BaseResponse.of(SuccessStatus.NURSE_REQUEST_RETRIED, new HashMap<>());
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/fcm/api/FcmController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/fcm/api/FcmController.java
@@ -49,10 +49,9 @@ public class FcmController {
     @PostMapping("/alarm/{patientId}")
     public BaseResponse<Void> sendAlarm(@PathVariable(name = "patientId") Long patientId) {
         Patient patient = patientService.getPatient(patientId);
-        // TODO
-        // String token = fcmService.findClientToken(patient.getNurse());
+        String token = fcmService.findClientToken(patient.getNurse());
 
-        fcmService.abnormalBehaviorAlarm(patient, "refresh");
+        fcmService.abnormalBehaviorAlarm(patient, token);
 
         return BaseResponse.of(SuccessStatus.ALARM_SUCCESS, null);
     }

--- a/src/main/java/aurora/carevisionapiserver/global/fcm/converter/AlarmConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/global/fcm/converter/AlarmConverter.java
@@ -20,6 +20,7 @@ public class AlarmConverter {
                         .inpatientWardNumber(patient.getBed().getInpatientWardNumber())
                         .patientRoomNumber(patient.getBed().getPatientRoomNumber())
                         .bedNumber(patient.getBed().getBedNumber())
+                        .read(false)
                         .build();
         return toMap(alarmData);
     }
@@ -32,6 +33,7 @@ public class AlarmConverter {
     public static AlarmInfoResponse toAlarmInfoResponse(
             FireStoreResponse alarmInfo, String timeAgo) {
         return AlarmInfoResponse.builder()
+                .documentId(alarmInfo.getDocumentId())
                 .patientId(alarmInfo.getPatientId())
                 .patientName(alarmInfo.getPatientName())
                 .inpatientWardNumber(alarmInfo.getInpatientWardNumber())

--- a/src/main/java/aurora/carevisionapiserver/global/fcm/dto/AlarmResponse.java
+++ b/src/main/java/aurora/carevisionapiserver/global/fcm/dto/AlarmResponse.java
@@ -16,6 +16,7 @@ public class AlarmResponse {
         private long inpatientWardNumber;
         private long patientRoomNumber;
         private long bedNumber;
+        private boolean read;
     }
 
     @Getter
@@ -23,6 +24,7 @@ public class AlarmResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class AlarmInfoResponse {
+        private String documentId;
         private int inpatientWardNumber;
         private int patientRoomNumber;
         private int bedNumber;

--- a/src/main/java/aurora/carevisionapiserver/global/fcm/dto/FcmResponse.java
+++ b/src/main/java/aurora/carevisionapiserver/global/fcm/dto/FcmResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class FcmResponse {
     @Getter
@@ -13,11 +14,13 @@ public class FcmResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class FireStoreResponse {
+        @Setter private String documentId;
         private long patientId;
         private String patientName;
         private int inpatientWardNumber;
         private int patientRoomNumber;
         private int bedNumber;
         private Timestamp time;
+        private boolean read;
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/fcm/service/FcmService.java
+++ b/src/main/java/aurora/carevisionapiserver/global/fcm/service/FcmService.java
@@ -1,5 +1,6 @@
 package aurora.carevisionapiserver.global.fcm.service;
 
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.global.fcm.dto.AlarmResponse.AlarmInfoListResponse;
@@ -13,4 +14,6 @@ public interface FcmService {
     void abnormalBehaviorAlarm(Patient patient, String registrationToken);
 
     AlarmInfoListResponse getAlarmsInfo(Nurse nurse);
+
+    StreamingInfoResponse getAlarmInfo(Nurse nurse, String documentId);
 }

--- a/src/main/java/aurora/carevisionapiserver/global/fcm/service/Impl/FcmServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/global/fcm/service/Impl/FcmServiceImpl.java
@@ -89,6 +89,7 @@ public class FcmServiceImpl implements FcmService {
                         .putData("patientName", patient.getName())
                         .putData("patientId", patient.getId().toString())
                         .putData("time", time.toString())
+                        .putData("read", "false")
                         .setToken(registrationToken)
                         .build();
         try {
@@ -141,6 +142,7 @@ public class FcmServiceImpl implements FcmService {
 
         for (QueryDocumentSnapshot document : querySnapshot.getDocuments()) {
             FireStoreResponse fireStoreInfo = document.toObject(FireStoreResponse.class);
+            fireStoreInfo.setDocumentId(document.getId());
             responses.add(fireStoreInfo);
         }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #166
Close #169 

## 📌 개요
- a95e0bf238c23505e535b79958aff820b0b3051b : documentId를 응답값으로 추가해 리스트 조회시 응답값을 받고, 그 응답값으로 상세조회가 가능하도록 설정했습니다
- 상세조회할 때 firestore의 read값을 **true**로 설정했습니다 .
- 614749bf87d44b019b1bfe2db35f4cca4a8ea601 기존 임시 설정해두었던 토큰 값을 다시 돌려두었습니다!!
- 새로 생성한 조회 api는 기존 스트리밍 조회 기능에 firestore값 업데이트 기능을 추가했습니다. 
- b5e0ed2b72de93969afec20332ccb76e01c6ae88 : null로 리턴되던 응답값 빈 리스트로 응답하도록 수정했습ㄴ다!!!

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
