### PR TITLE
[fix] 썸네일 데이터가 하나 남았을시 삭제되지 않도록 수정

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/S3Service.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/S3Service.java
@@ -46,7 +46,7 @@ public class S3Service {
                 new Date(System.currentTimeMillis() - (daysOld * 24L * 60 * 60 * 1000));
 
         for (S3ObjectSummary summary : objectSummaries) {
-            if (summary.getLastModified().before(thresholdDate)) {
+            if (summary.getSize() != 1 && summary.getLastModified().before(thresholdDate)) {
                 String objectKey = summary.getKey();
                 amazonS3.deleteObject(bucket, objectKey);
             }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #170

## 📌 개요
- 현재 카메라 연결이 끊겨있는데, 썸네일이 스케쥴러를 돌며 주기적으로 삭제되다보니 남아있는 데이터가 없어 조회시 문제가 되었습니다.
=> 남은 썸네일 데이터가 하나일 경우 삭제 되지 않는 조건을 추가했습니다. 

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
