### PR TITLE
[feat] 저장된 영상 데이터 조회 API & 저장된 영상 데이터 상세 조회 API

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraController.java
@@ -9,8 +9,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import aurora.carevisionapiserver.domain.camera.converter.CameraConverter;
+import aurora.carevisionapiserver.domain.camera.domain.Video;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingListResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoListResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoLinkResponse;
 import aurora.carevisionapiserver.domain.camera.service.CameraService;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
@@ -61,5 +65,34 @@ public class NurseCameraController {
         Map<Patient, String> streamingInfo = cameraService.getStreamingInfo(patients);
         return BaseResponse.of(
                 SuccessStatus._OK, CameraConverter.toStreamingListResponse(streamingInfo));
+    }
+
+    @Operation(
+            summary = "특정 환자의 저장된 비디오 리스트 조회 API",
+            description = "특정 환자의 저장된 비디오 영상 리스트를 조회합니다(저장 일자, 영상 길이, 썸네일)_예림")
+    @ApiResponses({
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+        @ApiResponse(responseCode = "PATIENT400", description = "NOT FOUND, 환자가 없습니다.")
+    })
+    @GetMapping("/patients/{patientId}/videos")
+    public BaseResponse<VideoInfoListResponse> getSavedVideoInfos(
+            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
+            @PathVariable(name = "patientId") Long patientId) {
+        List<VideoInfoResponse> videoInfoResponses = cameraService.getSavedVideoInfos(patientId);
+        return BaseResponse.of(
+                SuccessStatus._OK, CameraConverter.toVideoInfoListResponse(videoInfoResponses));
+    }
+
+    @Operation(summary = "특정 환자의 저장된 비디오 상세 조회 API", description = "특정 환자의 저장된 비디오 영상을 상세 조회합니다_예림")
+    @ApiResponses({
+        @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+        @ApiResponse(responseCode = "PATIENT400", description = "NOT FOUND, 환자가 없습니다.")
+    })
+    @GetMapping("/videos/{videoId}")
+    public BaseResponse<VideoLinkResponse> getSavedVideo(
+            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
+            @PathVariable(name = "videoId") Long videoId) {
+        Video video = cameraService.getSavedVideo(videoId);
+        return BaseResponse.of(SuccessStatus._OK, CameraConverter.toVideoLinkRespose(video));
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/converter/CameraConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/converter/CameraConverter.java
@@ -2,16 +2,21 @@ package aurora.carevisionapiserver.domain.camera.converter;
 
 import static aurora.carevisionapiserver.domain.bed.converter.BedConverter.toBedInfoResponse;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
+import aurora.carevisionapiserver.domain.camera.domain.Video;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.CameraInfoListResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.CameraInfoResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingListResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoListResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoLinkResponse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 
 public class CameraConverter {
@@ -62,5 +67,28 @@ public class CameraConverter {
                 .thumbnail(thumbnail)
                 .bedInfo(toBedInfoResponse(patient.getBed()))
                 .build();
+    }
+
+    public static VideoInfoListResponse toVideoInfoListResponse(
+            List<VideoInfoResponse> videoInfoResponses) {
+        return VideoInfoListResponse.builder()
+                .videoInfoList(videoInfoResponses)
+                .totalCount((long) videoInfoResponses.size())
+                .build();
+    }
+
+    public static VideoInfoResponse toVideoInfoResponse(
+            Video video, String thumbnail, String duration) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+        return VideoInfoResponse.builder()
+                .videoId(video.getId())
+                .thumbnail(thumbnail)
+                .name(video.getCreatedAt().format(formatter))
+                .length(duration)
+                .build();
+    }
+
+    public static VideoLinkResponse toVideoLinkRespose(Video video) {
+        return VideoLinkResponse.builder().link(video.getLink()).build();
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/dto/response/CameraResponse.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/dto/response/CameraResponse.java
@@ -46,4 +46,26 @@ public class CameraResponse {
         List<StreamingResponse> streamingResponse;
         Long totalCount;
     }
+
+    @Getter
+    @Builder
+    public static class VideoInfoListResponse {
+        List<VideoInfoResponse> videoInfoList;
+        Long totalCount;
+    }
+
+    @Getter
+    @Builder
+    public static class VideoInfoResponse {
+        Long videoId;
+        String thumbnail;
+        String name;
+        String length;
+    }
+
+    @Getter
+    @Builder
+    public static class VideoLinkResponse {
+        String link;
+    }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/exception/CameraException.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/exception/CameraException.java
@@ -1,0 +1,10 @@
+package aurora.carevisionapiserver.domain.camera.exception;
+
+import aurora.carevisionapiserver.global.response.code.BaseErrorCode;
+import aurora.carevisionapiserver.global.response.exception.GeneralException;
+
+public class CameraException extends GeneralException {
+    public CameraException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/repository/VideoRepository.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/repository/VideoRepository.java
@@ -1,0 +1,12 @@
+package aurora.carevisionapiserver.domain.camera.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import aurora.carevisionapiserver.domain.camera.domain.Video;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+
+public interface VideoRepository extends JpaRepository<Video, Long> {
+    List<Video> findByPatient(Patient patient);
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/CameraService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/CameraService.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
+import aurora.carevisionapiserver.domain.camera.domain.Video;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.global.auth.domain.User;
 
@@ -16,4 +18,10 @@ public interface CameraService {
     String getStreamingUrl(Patient patient);
 
     Map<Patient, String> getStreamingInfo(List<Patient> patients);
+
+    List<VideoInfoResponse> getSavedVideoInfos(Long patientId);
+
+    Video getSavedVideo(Long videoId);
+
+    Video getVideo(Long videoId);
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
@@ -8,13 +8,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
+import aurora.carevisionapiserver.domain.camera.converter.CameraConverter;
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
+import aurora.carevisionapiserver.domain.camera.domain.Video;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
+import aurora.carevisionapiserver.domain.camera.exception.CameraException;
 import aurora.carevisionapiserver.domain.camera.repository.CameraRepository;
+import aurora.carevisionapiserver.domain.camera.repository.VideoRepository;
 import aurora.carevisionapiserver.domain.camera.service.CameraService;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
-import aurora.carevisionapiserver.domain.patient.exception.CameraException;
+import aurora.carevisionapiserver.domain.patient.service.PatientService;
 import aurora.carevisionapiserver.global.auth.domain.User;
-import aurora.carevisionapiserver.global.auth.service.S3Service;
+import aurora.carevisionapiserver.global.infra.aws.S3Service;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 
@@ -23,12 +28,15 @@ import lombok.RequiredArgsConstructor;
 public class CameraServiceImpl implements CameraService {
     private static final int CAMERA_IP_INDEX = 0;
     private static final int CAMERA_PW_INDEX = 1;
+
     private final S3Service s3Service;
+    private final PatientService patientService;
 
     @Value("${camera.streaming.url}")
     String urlFormat;
 
     private final CameraRepository cameraRepository;
+    private final VideoRepository videoRepository;
 
     public List<Camera> getAllCameraInfo(Admin admin) {
         return cameraRepository.findAllCamerasSortedByBed(admin.getDepartment().getId());
@@ -51,6 +59,32 @@ public class CameraServiceImpl implements CameraService {
         return patients.stream().collect(Collectors.toMap(patient -> patient, this::getThumbnail));
     }
 
+    @Override
+    public List<VideoInfoResponse> getSavedVideoInfos(Long patientId) {
+        Patient patient = patientService.getPatient(patientId);
+        List<Video> videos = videoRepository.findByPatient(patient);
+        return videos.stream().map(this::createVideoInfoResponse).collect(Collectors.toList());
+    }
+
+    @Override
+    public Video getSavedVideo(Long videoId) {
+        return getVideo(videoId);
+    }
+
+    @Override
+    public Video getVideo(Long videoId) {
+        return videoRepository
+                .findById(videoId)
+                .orElseThrow(() -> new CameraException(ErrorStatus.VIDEO_NOT_FOUND));
+    }
+
+    private VideoInfoResponse createVideoInfoResponse(Video video) {
+        String duration = s3Service.getVideoDuration(video.getLink());
+        String thumbnail =
+                s3Service.getSavedVideoThumbnail(video.getPatient().getId(), video.getId());
+        return CameraConverter.toVideoInfoResponse(video, thumbnail, duration);
+    }
+
     private String getThumbnail(Patient patient) {
         Long patientId = patient.getId();
         return s3Service.getRecentImage(patientId);
@@ -60,7 +94,10 @@ public class CameraServiceImpl implements CameraService {
         Camera camera =
                 cameraRepository
                         .findByPatient(patient)
-                        .orElseThrow(() -> new CameraException(ErrorStatus.CAMERA_NOT_FOUND));
+                        .orElseThrow(
+                                () ->
+                                        new aurora.carevisionapiserver.domain.patient.exception
+                                                .CameraException(ErrorStatus.CAMERA_NOT_FOUND));
         return List.of(camera.getIp(), camera.getPassword());
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/auth/service/S3Service.java
+++ b/src/main/java/aurora/carevisionapiserver/global/auth/service/S3Service.java
@@ -46,7 +46,7 @@ public class S3Service {
                 new Date(System.currentTimeMillis() - (daysOld * 24L * 60 * 60 * 1000));
 
         for (S3ObjectSummary summary : objectSummaries) {
-            if (summary.getLastModified().before(thresholdDate)) {
+            if (summary.getSize() != 1 && summary.getLastModified().before(thresholdDate)) {
                 String objectKey = summary.getKey();
                 amazonS3.deleteObject(bucket, objectKey);
             }

--- a/src/main/java/aurora/carevisionapiserver/global/config/SchedulerConfig.java
+++ b/src/main/java/aurora/carevisionapiserver/global/config/SchedulerConfig.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import aurora.carevisionapiserver.domain.camera.service.RtspService;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
-import aurora.carevisionapiserver.global.auth.service.S3Service;
+import aurora.carevisionapiserver.global.infra.aws.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/aurora/carevisionapiserver/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/aurora/carevisionapiserver/global/response/code/status/ErrorStatus.java
@@ -50,11 +50,12 @@ public enum ErrorStatus implements BaseErrorCode {
     FRAME_PROCESSING_ERROR(HttpStatus.BAD_REQUEST, "CAMERA402", "프레임 처리 중 오류가 발생하였습니다."),
     GRABBER_STOP_FAILED(HttpStatus.BAD_REQUEST, "CAMERA403", "스트리밍 중지에 실패하였습니다."),
     EMPTY_S3_IMAGE(HttpStatus.NOT_FOUND, "CAMERA404", "S3에 이미지가 없습니다."),
+    INVALID_S3_LINK(HttpStatus.INTERNAL_SERVER_ERROR, "CAMERA405", "저장된 영상 링크 파싱 중 오류가 발생하였습니다."),
     // Bed
     INVALID_BED_INFO(
             HttpStatus.BAD_REQUEST, "BED400", "잘못된 형식의 베드 정보입니다. '동 호 번' 또는 '호 번' 순서로 작성해 주세요."),
     BED_NOT_FOUND(HttpStatus.NOT_FOUND, "BED401", "베드를 찾을 수 없습니다."),
-    // fcm
+    // Fcm
     CLIENT_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "FCM400", "token이 만료되었습니다."),
     CLIENT_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "FCM401", "token을 찾을 수 없습니다."),
     EXECUTION_FAILED(HttpStatus.BAD_REQUEST, "FCM402", "FireStore에서 데이터를 불러오는 실행 도중 오류가 발생하였습니다."),
@@ -63,9 +64,12 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_INVALID_TOKEN(
             HttpStatus.BAD_REQUEST, "FCM402", "FireStore에서 데이터를 불러오는 실행 도중 오류가 발생하였습니다."),
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "FCM402", "FireStore에서 데이터를 불러오는 실행 도중 오류가 발생하였습니다."),
-    // FILE
+    // File
     FILE_CONVERT_FAIL(HttpStatus.BAD_REQUEST, "FILE400", "파일 변환에 실패하였습니다."),
-    ;
+
+    // Video
+    VIDEO_NOT_FOUND(HttpStatus.BAD_REQUEST, "VIDEO400", "영상을 찾을 수 없습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #167

## 📌 개요
- S3 버킷에 더미 데이터 삽입
- 저장된 영상 데이터 조회 API (`GET /api/patients/{patientId}/videos`)를 구현했습니다.
- 저장된 영상 데이터 상세 조회 API (`GET /api/videos/{videoId}`)를 구현했습니다.

## 🔁 변경 사항
- **더미 데이터 삽입**
  - 비디오 파일은 `video/{patientId}/{videoId}.mp4` 형식
  - 썸네일은 `thumbnails-for-saved-video/{patientId}/{videoId}.jpg` 형식으로 저장했습니다.
    - 이 때 videoId는 실제 DB에 저장되는 videoId가 아니라 비디오가 저장되는 순서에 따라 1부터 부여된 번호입니다! 더미 데이터이므로 일단 이렇게 넣어놓았습니다.
  - 비디오 길이는 S3에서 파일 업로드 시 다음과 같이 메타 데이터` x-amz-meta-duration`키에 값으로 지정하였습니다.

    <img width="1169" alt="image" src="https://github.com/user-attachments/assets/a08afa6a-f040-4a07-9271-d451fd053960">


      - 이는 다음과 같이 가져올 수 있습니다.
    
    ```java
    public String getVideoDuration(String link) {
      String key = extractS3Key(link);
      Map<String, String> metadata = getObjectMetadata(VIDEO_PATH + key);
      return metadata.get("duration");
    }
    ```
- 저장된 영상 데이터 조회 API (`GET /api/patients/{patientId}/videos`) 구현 시
  - 비디오가 저장될 때 이름이 설정되는 게 맞는데, 일단 우리는 업로드를 수동으로 하고 있으므로 일단은 `createdAt`에서 직접 formatter로 이름을 만들어서 보내주도록 구현했습니다.

- s3Service의 위치가 `auth`에 있어서 `infra/s3`로 옮겼습니다



## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 현재 저희 프로젝트에서 Service 계층에서 Entity를 반환하는 구조와 DTO를 반환하는 구조가 섞여 있는데 나중에 방식은 통일하는 게 좋을듯합니다!
  - 현재 저장된 영상 데이터 조회 API (`GET /api/patients/{patientId}/videos`) 구현 시에는 Service 계층에서 DTO를 반환하도록 구현했습니다. (도메인을 반환하게 되면 썸네일, 영상 길이를 가져오는 메서드 또한 컨트롤러 계층에서 호출해야 하는데, 그럼 비즈니스 로직이 컨트롤러에 너무 많아진다고 느껴져 같아 일단은 Service 계층에서 처리하여 DTO를 반환하도록 했습니다.)
  - 현재 CUD 요청 관련해서는 DTO를 바로 서비스 계층에 넘겨주고 있고, Read 요청에 대해서는 서비스 계층에서 Domain을 반환하고 있더라구요 (Read 요청에 대해서 DTO를 반환하는 로직도 존재)
- 나중에 통일한다면 다 장단점이 있지만 서비스 계층에서 DTO를 반환하는 방식으로 바꾸는 것도 좋다고 생각합니다!
  - 이에 대해서 발견한 좋은 글들 :
    - [DTO의 사용 범위에 대하여](https://tecoble.techcourse.co.kr/post/2021-04-25-dto-layer-scope/)
    - [Controller, Service 레이어에서 DTO의 사용](https://shyun00.tistory.com/214)

- 또, 단순히 카메라를 조회하는 로직과 영상과 관련된 로직이 camera 도메인에 있는 것보다는 나중에 video 도메인 따로 만들어 분리하는 게 좋을 것 같습니다!! 나중에,, 

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
