### PR TITLE
[feat] 간호사 담당 환자 스트리밍 정보 조회 시 커서 기반 페이지네이션 추가 및 테스트 환경 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ dependencies {
     //es
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
+    //h2
+    implementation 'com.h2database:h2'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraController.java
@@ -3,15 +3,18 @@ package aurora.carevisionapiserver.domain.camera.api;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import aurora.carevisionapiserver.domain.camera.converter.CameraConverter;
 import aurora.carevisionapiserver.domain.camera.domain.Video;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
-import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingListResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingPageResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoListResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoLinkResponse;
@@ -19,6 +22,7 @@ import aurora.carevisionapiserver.domain.camera.service.CameraService;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
+import aurora.carevisionapiserver.global.common.service.PageService;
 import aurora.carevisionapiserver.global.response.BaseResponse;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
 import aurora.carevisionapiserver.global.security.handler.annotation.AuthUser;
@@ -36,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 public class NurseCameraController {
     private final CameraService cameraService;
     private final PatientService patientService;
+    private final PageService pageService;
 
     @Operation(summary = "특정 환자 실시간 영상 스트리밍 관련 정보 조회 API", description = "환자의 스트리밍 관련 정보를 조회합니다_숙희")
     @ApiResponses({
@@ -59,12 +64,19 @@ public class NurseCameraController {
         @ApiResponse(responseCode = "CAMERA400", description = "NOT FOUND, 카메라를 찾을 수 없습니다.")
     })
     @GetMapping("/streaming")
-    public BaseResponse<StreamingListResponse> getStreamingInfoList(
-            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse) {
-        List<Patient> patients = patientService.getPatients(nurse);
-        Map<Patient, String> streamingInfo = cameraService.getStreamingInfo(patients);
+    public BaseResponse<StreamingPageResponse> getStreamingInfoList(
+            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
+            @RequestParam(value = "lastIdx") Long lastIdx,
+            @PageableDefault(size = 8, sort = "id") @RequestParam(value = "size") int size) {
+        Slice<Patient> patients = patientService.getPatientSlice(nurse, lastIdx, size);
+        Map<Patient, String> streamingInfo = cameraService.getStreamingInfo(patients.getContent());
+
         return BaseResponse.of(
-                SuccessStatus._OK, CameraConverter.toStreamingListResponse(streamingInfo));
+                SuccessStatus._OK,
+                CameraConverter.toStreamingPageResponse(
+                        streamingInfo,
+                        patients.hasNext(),
+                        pageService.getNextCursor(size, patients.getContent())));
     }
 
     @Operation(

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/converter/CameraConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/converter/CameraConverter.java
@@ -9,10 +9,10 @@ import java.util.stream.Collectors;
 
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
 import aurora.carevisionapiserver.domain.camera.domain.Video;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.CameraInfoListResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.CameraInfoResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
-import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingListResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoListResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
@@ -46,26 +46,26 @@ public class CameraConverter {
                 .build();
     }
 
-    public static StreamingListResponse toStreamingListResponse(
-            Map<Patient, String> streamingInfo) {
-
-        List<StreamingResponse> responses =
-                streamingInfo.entrySet().stream()
-                        .map(entry -> toStreamingResponse(entry.getKey(), entry.getValue()))
-                        .collect(Collectors.toList());
-
-        return StreamingListResponse.builder()
-                .streamingResponse(responses)
-                .totalCount((long) responses.size())
-                .build();
-    }
-
     private static StreamingResponse toStreamingResponse(Patient patient, String thumbnail) {
         return StreamingResponse.builder()
                 .patientId(patient.getId())
                 .patientName(patient.getName())
                 .thumbnail(thumbnail)
                 .bedInfo(toBedInfoResponse(patient.getBed()))
+                .build();
+    }
+
+    public static CameraResponse.StreamingPageResponse toStreamingPageResponse(
+            Map<Patient, String> streamingInfo, boolean hasNext, Long nextCursor) {
+        List<StreamingResponse> responses =
+                streamingInfo.entrySet().stream()
+                        .map(entry -> toStreamingResponse(entry.getKey(), entry.getValue()))
+                        .collect(Collectors.toList());
+
+        return CameraResponse.StreamingPageResponse.builder()
+                .streamingResponse(responses)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
                 .build();
     }
 

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/converter/CameraConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/converter/CameraConverter.java
@@ -9,10 +9,10 @@ import java.util.stream.Collectors;
 
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
 import aurora.carevisionapiserver.domain.camera.domain.Video;
-import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.CameraInfoListResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.CameraInfoResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingInfoResponse;
+import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingPageResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.StreamingResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoListResponse;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
@@ -55,14 +55,14 @@ public class CameraConverter {
                 .build();
     }
 
-    public static CameraResponse.StreamingPageResponse toStreamingPageResponse(
+    public static StreamingPageResponse toStreamingPageResponse(
             Map<Patient, String> streamingInfo, boolean hasNext, Long nextCursor) {
         List<StreamingResponse> responses =
                 streamingInfo.entrySet().stream()
                         .map(entry -> toStreamingResponse(entry.getKey(), entry.getValue()))
                         .collect(Collectors.toList());
 
-        return CameraResponse.StreamingPageResponse.builder()
+        return StreamingPageResponse.builder()
                 .streamingResponse(responses)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/dto/response/CameraResponse.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/dto/response/CameraResponse.java
@@ -42,9 +42,10 @@ public class CameraResponse {
 
     @Getter
     @Builder
-    public static class StreamingListResponse {
+    public static class StreamingPageResponse {
         List<StreamingResponse> streamingResponse;
-        Long totalCount;
+        boolean hasNext;
+        Long nextCursor;
     }
 
     @Getter

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepository.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepository.java
@@ -2,6 +2,8 @@ package aurora.carevisionapiserver.domain.patient.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Slice;
+
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
@@ -10,4 +12,6 @@ public interface CustomPatientRepository {
     List<Patient> findPatientByAdmin(Admin admin);
 
     List<Patient> findUnlinkedPatientsByNurse(Nurse nurse);
+
+    Slice<Patient> findPatientByNurse(Nurse nurse, Long lastIdx, int size);
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepositoryImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepositoryImpl.java
@@ -2,8 +2,12 @@ package aurora.carevisionapiserver.domain.patient.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
@@ -41,5 +45,33 @@ public class CustomPatientRepositoryImpl implements CustomPatientRepository {
                                 .eq(nurse.getDepartment().getHospital())
                                 .and(patient.nurse.isNull()))
                 .fetch();
+    }
+
+    @Override
+    public Slice<Patient> findPatientByNurse(Nurse nurse, Long lastIdx, int size) {
+        QPatient patient = QPatient.patient;
+
+        List<Patient> patients =
+                queryFactory
+                        .select(patient)
+                        .from(patient)
+                        .where(isGreaterThan(patient, lastIdx).and(isEqTo(patient, nurse)))
+                        .limit(size + 1)
+                        .fetch();
+
+        boolean hasNext = patients.size() > size;
+        if (hasNext) {
+            patients = patients.subList(0, Math.toIntExact(size));
+        }
+
+        return new SliceImpl<>(patients, Pageable.unpaged(), hasNext);
+    }
+
+    private static BooleanExpression isEqTo(QPatient patient, Nurse nurse) {
+        return patient.nurse.eq(nurse);
+    }
+
+    private static BooleanExpression isGreaterThan(QPatient patient, Long lastIdx) {
+        return patient.id.gt(lastIdx);
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepositoryImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepositoryImpl.java
@@ -61,7 +61,7 @@ public class CustomPatientRepositoryImpl implements CustomPatientRepository {
 
         boolean hasNext = patients.size() > size;
         if (hasNext) {
-            patients = patients.subList(0, Math.toIntExact(size));
+            patients = patients.subList(0, size);
         }
 
         return new SliceImpl<>(patients, Pageable.unpaged(), hasNext);

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,6 +62,11 @@ public class PatientServiceImpl implements PatientService {
         Admin admin = adminService.getAdmin(adminId);
 
         return patientRepository.findPatientByAdmin(admin);
+    }
+
+    @Override
+    public Slice<Patient> getPatientSlice(Nurse nurse, Long lastIdx, int size) {
+        return patientRepository.findPatientByNurse(nurse, lastIdx, size);
     }
 
     public Patient getPatientsByPatientId(String patientCode) {

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -69,13 +69,6 @@ public class PatientServiceImpl implements PatientService {
         return patientRepository.findPatientByNurse(nurse, lastIdx, size);
     }
 
-    public Patient getPatientsByPatientId(String patientCode) {
-        Patient patient = patientRepository.findPatientByCode(patientCode);
-        if (patient == null) throw new PatientException(ErrorStatus.PATIENT_NOT_FOUND);
-
-        return patientRepository.findPatientByCode(patientCode);
-    }
-
     @Override
     public void deletePatient(Long patientId) {
         Patient patient = getPatient(patientId);

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/PatientService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/PatientService.java
@@ -3,6 +3,8 @@ package aurora.carevisionapiserver.domain.patient.service;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.data.domain.Slice;
+
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.bed.domain.Bed;
 import aurora.carevisionapiserver.domain.camera.dto.request.CameraRequest.CameraSelectRequest;
@@ -19,6 +21,8 @@ public interface PatientService {
     List<Patient> getPatients(Nurse nurse);
 
     List<Patient> getPatients(Long adminId);
+
+    Slice<Patient> getPatientSlice(Nurse nurse, Long lastIdx, int size);
 
     void deletePatient(Long patientId);
 

--- a/src/main/java/aurora/carevisionapiserver/global/common/service/PageService.java
+++ b/src/main/java/aurora/carevisionapiserver/global/common/service/PageService.java
@@ -1,0 +1,9 @@
+package aurora.carevisionapiserver.global.common.service;
+
+import java.util.List;
+
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+
+public interface PageService {
+    Long getNextCursor(int size, List<Patient> patients);
+}

--- a/src/main/java/aurora/carevisionapiserver/global/common/service/impl/PageServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/global/common/service/impl/PageServiceImpl.java
@@ -1,0 +1,22 @@
+package aurora.carevisionapiserver.global.common.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.global.common.service.PageService;
+
+@Service
+public class PageServiceImpl implements PageService {
+    private static final Long DEFAULT_CURSOR = -1L;
+
+    @Override
+    public Long getNextCursor(int size, List<Patient> patients) {
+        Long nextCursor = DEFAULT_CURSOR;
+        if (patients.size() == size) {
+            nextCursor = patients.get(size - 1).getId();
+        }
+        return nextCursor;
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,31 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: ${TEST_USERNAME}
+    password: ${TEST_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: ${LOCAL_REDIS_URL}
+      port: 6379
+
+elasticsearch:
+  uris: ${LOCAL_ES_URIS}
+  username: ${LOCAL_ES_USERNAME}
+  password: ${LOCAL_ES_PASSWORD}
+  connection:
+    timeout: ${ES_CONNECTION_TIMEOUT}
+  socket:
+    timeout: ${ES_SOCKET_TIMEOUT}

--- a/src/test/java/aurora/carevisionapiserver/ControllerTestSupport.java
+++ b/src/test/java/aurora/carevisionapiserver/ControllerTestSupport.java
@@ -1,0 +1,35 @@
+package aurora.carevisionapiserver;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import aurora.carevisionapiserver.domain.admin.repository.AdminRepository;
+import aurora.carevisionapiserver.domain.admin.service.AdminService;
+import aurora.carevisionapiserver.domain.camera.api.NurseCameraController;
+import aurora.carevisionapiserver.domain.camera.service.CameraService;
+import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
+import aurora.carevisionapiserver.domain.nurse.service.NurseService;
+import aurora.carevisionapiserver.domain.patient.service.PatientService;
+import aurora.carevisionapiserver.global.auth.util.JWTUtil;
+import aurora.carevisionapiserver.global.common.service.PageService;
+
+@WebMvcTest(
+        controllers = {
+            NurseCameraController.class,
+        })
+public abstract class ControllerTestSupport {
+    @Autowired protected MockMvc mockMvc;
+    @Autowired protected ObjectMapper objectMapper;
+    @MockBean protected CameraService cameraService;
+    @MockBean protected PatientService patientService;
+    @MockBean protected AdminService adminService;
+    @MockBean protected NurseService nurseService;
+    @MockBean protected PageService pageService;
+    @MockBean protected JWTUtil jwtUtil;
+    @MockBean protected NurseRepository nurseRepository;
+    @MockBean protected AdminRepository adminRepository;
+}

--- a/src/test/java/aurora/carevisionapiserver/IntegrationTestSupport.java
+++ b/src/test/java/aurora/carevisionapiserver/IntegrationTestSupport.java
@@ -1,0 +1,8 @@
+package aurora.carevisionapiserver;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public abstract class IntegrationTestSupport {}

--- a/src/test/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraControllerTest.java
@@ -1,0 +1,55 @@
+package aurora.carevisionapiserver.domain.camera.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import aurora.carevisionapiserver.ControllerTestSupport;
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
+
+class NurseCameraControllerTest extends ControllerTestSupport {
+    @WithMockUser
+    @DisplayName("담당하는 환자의 전체 스트리밍 관련 정보를 조회한다.")
+    @Test
+    void getStreamingInfoList() throws Exception {
+        // given
+        Bed bed = Bed.builder().bedNumber(1L).patientRoomNumber(2L).inpatientWardNumber(3L).build();
+        Patient patient = Patient.builder().id(1L).bed(bed).build();
+        Slice<Patient> patientSlice = new SliceImpl<>(List.of(patient));
+
+        // when //then
+        when(patientService.getPatientSlice(any(), anyLong(), anyInt())).thenReturn(patientSlice);
+        when(cameraService.getStreamingInfo(any()))
+                .thenReturn(Collections.singletonMap(patientSlice.getContent().get(0), "info"));
+        when(pageService.getNextCursor(anyInt(), any())).thenReturn(1L);
+
+        mockMvc.perform(
+                        get("/api/streaming")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(csrf())
+                                .param("lastIdx", "0")
+                                .param("size", "8"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(SuccessStatus._OK.getCode()))
+                .andExpect(jsonPath("$.result.streamingResponse").isArray())
+                .andExpect(jsonPath("$.result.hasNext").value(false))
+                .andExpect(jsonPath("$.result.nextCursor").value(1L));
+    }
+}

--- a/src/test/java/aurora/carevisionapiserver/repository/CustomPatientRepositoryImplTest.java
+++ b/src/test/java/aurora/carevisionapiserver/repository/CustomPatientRepositoryImplTest.java
@@ -1,0 +1,156 @@
+package aurora.carevisionapiserver.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Slice;
+
+import aurora.carevisionapiserver.IntegrationTestSupport;
+import aurora.carevisionapiserver.domain.hospital.domain.Department;
+import aurora.carevisionapiserver.domain.hospital.domain.Hospital;
+import aurora.carevisionapiserver.domain.hospital.repository.DepartmentRepository;
+import aurora.carevisionapiserver.domain.hospital.repository.HospitalRepository;
+import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
+import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.domain.patient.repository.CustomPatientRepositoryImpl;
+import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
+
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CustomPatientRepositoryImplTest extends IntegrationTestSupport {
+    @Autowired NurseRepository nurseRepository;
+    @Autowired PatientRepository patientRepository;
+    @Autowired HospitalRepository hospitalRepository;
+
+    @Autowired DepartmentRepository departmentRepository;
+
+    @Autowired CustomPatientRepositoryImpl customPatientRepository;
+    private Nurse nurse1;
+    private List<Patient> patientList;
+
+    @BeforeAll
+    void setup() {
+        Department department = createDepartment("department");
+        nurse1 = createNurse("nurse1", department);
+
+        Patient patient0 = createPatient(0L, "patient0", department, nurse1);
+        Patient patient1 = createPatient(1L, "patient1", department, nurse1);
+        Patient patient2 = createPatient(2L, "patient2", department, nurse1);
+        Patient patient3 = createPatient(3L, "patient3", department, nurse1);
+        Patient patient4 = createPatient(4L, "patient4", department, nurse1);
+        patientList = List.of(patient0, patient1, patient2, patient3, patient4);
+        patientRepository.saveAll(patientList);
+    }
+
+    @DisplayName("다음에 조회될 환자 리스트의 개수가 입력 사이즈보다 큰 경우 hasNext는 true이다.")
+    @Test
+    void findPatientByNurseWhenRemainingSizeIsGreaterThanInputSize() {
+        // given
+        Long lastIdx = 0L;
+        int size = 2;
+
+        Patient patientWhoId1 = patientList.get(1);
+        Patient patientWhoId2 = patientList.get(2);
+
+        // when
+        Slice<Patient> response = customPatientRepository.findPatientByNurse(nurse1, lastIdx, size);
+
+        // then
+        assertEquals(2, response.getContent().size());
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.getContent())
+                .extracting("id", "name")
+                .contains(
+                        tuple(patientWhoId1.getId(), patientWhoId1.getName()),
+                        tuple(patientWhoId2.getId(), patientWhoId2.getName()));
+    }
+
+    @DisplayName("입력된 사이즈와 동일한 개수의 항목이 조회될 때 hasNext는 false로 반환된다.")
+    @Test
+    void findPatientByNurseWhenLeftSizeIsSmallerThanInputSize() {
+        // given
+        Long lastIdx = 2L;
+        int size = 2;
+
+        Patient patientWhoId3 = patientList.get(3);
+        Patient patientWhoId4 = patientList.get(4);
+
+        // when
+        Slice<Patient> response = customPatientRepository.findPatientByNurse(nurse1, lastIdx, size);
+
+        // then
+        assertEquals(2, response.getContent().size());
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.getContent())
+                .extracting("id", "name")
+                .contains(
+                        tuple(patientWhoId3.getId(), patientWhoId3.getName()),
+                        tuple(patientWhoId4.getId(), patientWhoId4.getName()));
+    }
+
+    @DisplayName("다음에 조회될 환자 리스트의 크기가 입력 사이즈보다 작을 경우에도, 조회된 내용은 정상적으로 반환되며 hasNext는 false로 반환된다.")
+    @Test
+    void findPatientByNurseWhenNoPatientsAfterLastIndex() {
+        // given
+        Long lastIdx = 3L;
+        int size = 2;
+
+        Patient patientWhoId4 = patientList.get(4);
+
+        // when
+        Slice<Patient> response = customPatientRepository.findPatientByNurse(nurse1, lastIdx, size);
+
+        // then
+        assertEquals(1, response.getContent().size());
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.getContent())
+                .extracting("id", "name")
+                .contains(tuple(patientWhoId4.getId(), patientWhoId4.getName()));
+    }
+
+    @DisplayName("다음에 조회될 환자 리스트가 없는 경우 hasNext는 false로 반환한다.")
+    @Test
+    void findPatientByNurseWhenNoPatientsLeft() {
+        // given
+        Long lastIdx = 4L;
+        int size = 2;
+
+        // when
+        Slice<Patient> response = customPatientRepository.findPatientByNurse(nurse1, lastIdx, size);
+
+        // then
+        assertEquals(0, response.getContent().size());
+        assertThat(response.hasNext()).isFalse();
+    }
+
+    private Department createDepartment(String name) {
+        Hospital hospital = createHospital();
+        Department department = Department.builder().hospital(hospital).name(name).build();
+        return departmentRepository.save(department);
+    }
+
+    private Hospital createHospital() {
+        Hospital hospital = Hospital.builder().name("hospital").build();
+        return hospitalRepository.save(hospital);
+    }
+
+    private Nurse createNurse(String name, Department department) {
+        Nurse nurse = Nurse.builder().name(name).department(department).build();
+        return nurseRepository.save(nurse);
+    }
+
+    private Patient createPatient(Long id, String name, Department department, Nurse nurse1) {
+        return Patient.builder().id(id).name(name).nurse(nurse1).department(department).build();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #188

## 📌 개요
1. **응답형식**을 다음과 같이 수정했고 기존에 있던 `totalCount` 는 삭제했습니다. 
```
public static class StreamingPageResponse {
        List<StreamingResponse> streamingResponse;
        boolean hasNext;
        Long nextCursor;
    }
``` 

2. [커서 기반 페이지네이션](https://coordinated-muskmelon-1dd.notion.site/19b52b8b99e580598669fac710732016?pvs=4)을  QueryDSL을 사용하여 구현하였습니다.
- findPatientByNurse 메서드에 커서 기반 페이징 기능을 추가하여, **마지막으로 조회된 ID를 기준**으로 환자를 조회할 수 있도록 수정하였습니다.
- 커서 기반 페이지네이션을 통해 한 번에 가져오는 데이터의 양을 줄이고, 페이지네이션 처리 시 더 빠르고 효율적인 결과를 얻도록 했습니다. 

## 🔁 변경 사항
- 테스트 환경을 위한 yml 파일 생성했습니다. 

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/d4bec0a0-43fd-4d0b-8e04-421221c3ae51" width="500" />
<img src="https://github.com/user-attachments/assets/51ecdbf3-e475-415b-a9b7-36c25f4707cf" width="500" />

- 테스트를 통해 정상적으로 동작하는지 검증했습니다!

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
