### PR TITLE
[feat] 연결되지 않은 환자 목록 조회 API에 ElasticSearch 도입으로 성능 개선

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/AdminNurseController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/AdminNurseController.java
@@ -58,6 +58,7 @@ public class AdminNurseController {
     @RefreshTokenApiResponse
     @GetMapping("/nurses/search")
     public BaseResponse<NursePreviewListResponse> searchNurse(
+            @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
             @RequestParam(name = "search") String nurseName) {
         List<NurseDocument> nurses = nurseService.searchNurse(nurseName);
         return BaseResponse.onSuccess(NurseConverter.toNurseDocumentPreviewListResponse(nurses));

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
@@ -27,6 +27,7 @@ import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.Pati
 import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.PatientRegisterRequest;
 import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.PatientSelectRequest;
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientProfileListResponse;
+import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
 import aurora.carevisionapiserver.global.fcm.dto.response.AlarmPreviewResponse;
 import aurora.carevisionapiserver.global.fcm.dto.response.AlarmResponse.AlarmInfoListResponse;
@@ -128,18 +129,18 @@ public class NurseController {
     }
 
     @Operation(
-            summary = "아직 간호사와 연결되지 않은 환자 리스트 조회 API",
-            description = "등록되었지만 아직 간호사와 연결되지 않은 환자 리스트를 조회합니다._예림")
+            summary = "간호사와 연결되지 않은 환자 리스트 검색 API",
+            description = "간호사와 아직 연결되지 않은 등록된 환자 목록을 조회합니다. 검색어 없이 요청하면 전체 목록을 반환합니다._예림")
     @ApiResponses({
         @ApiResponse(responseCode = "COMMON202", description = "OK, 요청 성공 및 반환할 콘텐츠 없음"),
     })
     @RefreshTokenApiResponse
-    @GetMapping("/patients/unlinked")
-    public BaseResponse<PatientProfileListResponse> getUnlinkedPatientList(
-            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse) {
-        List<Patient> patients = patientService.getUnlinkedPatients(nurse);
-        return BaseResponse.of(
-                SuccessStatus._OK, PatientConverter.toPatientProfileListResponse(patients));
+    @GetMapping("/patients/unlinked/search")
+    public BaseResponse<PatientSearchListResponse> searchUnlinkedPatientList(
+            @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
+            @RequestParam(name = "search") String patientName) {
+        PatientSearchListResponse response = patientService.searchUnlinkedPatients(patientName);
+        return BaseResponse.onSuccess(response);
     }
 
     @Operation(summary = "간호사의 알람 리스트 조회 API", description = "간호사의 이상행동 감지 알람 리스트를 조회합니다._숙희")

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
@@ -138,7 +138,7 @@ public class NurseController {
     @GetMapping("/patients/unlinked/search")
     public BaseResponse<PatientSearchListResponse> searchUnlinkedPatientList(
             @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
-            @RequestParam(name = "search") String patientName) {
+            @RequestParam(name = "search", required = false) String patientName) {
         PatientSearchListResponse response = patientService.searchUnlinkedPatients(patientName);
         return BaseResponse.onSuccess(response);
     }

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/converter/NurseConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/converter/NurseConverter.java
@@ -98,8 +98,4 @@ public class NurseConverter {
             long count) {
         return NurseRegisterRequestCountResponse.from(count);
     }
-
-    public static NurseDocument toNurseDocument(Nurse nurse) {
-        return NurseDocument.builder().name(nurse.getName()).username(nurse.getUsername()).build();
-    }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/converter/NurseDocumentConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/converter/NurseDocumentConverter.java
@@ -1,0 +1,10 @@
+package aurora.carevisionapiserver.domain.nurse.converter;
+
+import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
+import aurora.carevisionapiserver.domain.nurse.domain.NurseDocument;
+
+public class NurseDocumentConverter {
+    public static NurseDocument toNurseDocument(Nurse nurse) {
+        return NurseDocument.builder().name(nurse.getName()).username(nurse.getUsername()).build();
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/service/Impl/NurseServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/service/Impl/NurseServiceImpl.java
@@ -2,6 +2,7 @@ package aurora.carevisionapiserver.domain.nurse.service.Impl;
 
 import java.util.List;
 
+import aurora.carevisionapiserver.domain.nurse.converter.NurseDocumentConverter;
 import jakarta.transaction.Transactional;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -89,7 +90,7 @@ public class NurseServiceImpl implements NurseService {
         Nurse nurse = getInactiveNurse(nurseId);
         nurse.activateNurse();
         nurseRepository.save(nurse);
-        nurseEsRepository.save(NurseConverter.toNurseDocument(nurse));
+        nurseEsRepository.save(NurseDocumentConverter.toNurseDocument(nurse));
     }
 
     @Override

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/service/Impl/NurseServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/service/Impl/NurseServiceImpl.java
@@ -2,7 +2,6 @@ package aurora.carevisionapiserver.domain.nurse.service.Impl;
 
 import java.util.List;
 
-import aurora.carevisionapiserver.domain.nurse.converter.NurseDocumentConverter;
 import jakarta.transaction.Transactional;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Service;
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
 import aurora.carevisionapiserver.domain.hospital.domain.Department;
 import aurora.carevisionapiserver.domain.nurse.converter.NurseConverter;
+import aurora.carevisionapiserver.domain.nurse.converter.NurseDocumentConverter;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.domain.NurseDocument;
 import aurora.carevisionapiserver.domain.nurse.dto.request.NurseRequest.NurseCreateRequest;

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/converter/PatientDocumentConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/converter/PatientDocumentConverter.java
@@ -1,15 +1,22 @@
 package aurora.carevisionapiserver.domain.patient.converter;
 
+import java.util.List;
+
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
 
 public class PatientDocumentConverter {
+    public static List<PatientDocument> toPatientDocumentList(List<Patient> patients) {
+        return patients.stream().map(PatientDocumentConverter::toPatientDocument).toList();
+    }
+
     public static PatientDocument toPatientDocument(Patient patient) {
         return PatientDocument.builder()
                 .name(patient.getName())
                 .code(patient.getCode())
                 .bedId(patient.getBed().getId())
                 .patientId(patient.getId())
+                .nurseId(patient.getNurse() != null ? patient.getNurse().getId() : -1L)
                 .build();
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/domain/PatientDocument.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/domain/PatientDocument.java
@@ -26,4 +26,7 @@ public class PatientDocument {
 
     @Field(type = FieldType.Long)
     private Long bedId;
+
+    @Field(type = FieldType.Long)
+    private Long nurseId;
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepository.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepository.java
@@ -11,7 +11,5 @@ import aurora.carevisionapiserver.domain.patient.domain.Patient;
 public interface CustomPatientRepository {
     List<Patient> findPatientByAdmin(Admin admin);
 
-    List<Patient> findUnlinkedPatientsByNurse(Nurse nurse);
-
     Slice<Patient> findPatientByNurse(Nurse nurse, Long lastIdx, int size);
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepositoryImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/repository/CustomPatientRepositoryImpl.java
@@ -34,20 +34,6 @@ public class CustomPatientRepositoryImpl implements CustomPatientRepository {
     }
 
     @Override
-    public List<Patient> findUnlinkedPatientsByNurse(Nurse nurse) {
-        QPatient patient = QPatient.patient;
-
-        return queryFactory
-                .selectFrom(patient)
-                .where(
-                        patient.department
-                                .hospital
-                                .eq(nurse.getDepartment().getHospital())
-                                .and(patient.nurse.isNull()))
-                .fetch();
-    }
-
-    @Override
     public Slice<Patient> findPatientByNurse(Nurse nurse, Long lastIdx, int size) {
         QPatient patient = QPatient.patient;
 

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepository.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepository.java
@@ -10,4 +10,8 @@ import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
 public interface PatientEsRepository extends ElasticsearchRepository<PatientDocument, String> {
     @Query("{\"match\": {\"name.ngram\": \"?0\"}}")
     List<PatientDocument> searchByName(String name);
+
+    @Query(
+            "{\"bool\": {\"must\": [ {\"match\": {\"name.ngram\": \"?0\"}}, {\"term\": {\"nurseId\": -1}} ] }}")
+    List<PatientDocument> searchByNameAndNurseIsNull(String name);
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepository.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepository.java
@@ -11,7 +11,10 @@ public interface PatientEsRepository extends ElasticsearchRepository<PatientDocu
     @Query("{\"match\": {\"name.ngram\": \"?0\"}}")
     List<PatientDocument> searchByName(String name);
 
+    @Query("{\"bool\": {\"must\": [ {\"term\": {\"nurseId\": -1}} ] }}")
+    List<PatientDocument> findAllByNurseIdIsNull();
+
     @Query(
             "{\"bool\": {\"must\": [ {\"match\": {\"name.ngram\": \"?0\"}}, {\"term\": {\"nurseId\": -1}} ] }}")
-    List<PatientDocument> searchByNameAndNurseIsNull(String name);
+    List<PatientDocument> findByNameAndNurseIdIsNull(String name);
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -15,9 +15,11 @@ import aurora.carevisionapiserver.domain.bed.service.BedService;
 import aurora.carevisionapiserver.domain.camera.dto.request.CameraRequest.CameraSelectRequest;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.service.NurseService;
+import aurora.carevisionapiserver.domain.patient.converter.PatientConverter;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
 import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.PatientCreateRequest;
+import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
 import aurora.carevisionapiserver.domain.patient.exception.PatientException;
 import aurora.carevisionapiserver.domain.patient.repository.PatientEsRepository;
 import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
@@ -39,17 +41,7 @@ public class PatientServiceImpl implements PatientService {
 
     public Map<PatientDocument, Bed> searchPatient(String patientName) {
         List<PatientDocument> patients = patientEsRepository.searchByName(patientName);
-        if (patients.size() == 0) throw new PatientException(ErrorStatus.PATIENT_NOT_FOUND);
-
-        Map<PatientDocument, Bed> patientInfo = new HashMap<>();
-
-        for (PatientDocument patient : patients) {
-            Long bedId = patient.getBedId();
-            Bed bed = bedService.findById(bedId);
-            patientInfo.put(patient, bed);
-        }
-
-        return patientInfo;
+        return getPatientDocumentBedMap(patients);
     }
 
     @Override
@@ -95,13 +87,12 @@ public class PatientServiceImpl implements PatientService {
         patientRegistrationService.createPatient(patientCreateRequest, admin.getDepartment());
     }
 
-    private void connectNurseToPatient(Patient patient, Nurse nurse) {
-        nurseService.connectPatient(nurse, patient);
-    }
-
     @Override
-    public List<Patient> getUnlinkedPatients(Nurse nurse) {
-        return patientRepository.findUnlinkedPatientsByNurse(nurse);
+    public PatientSearchListResponse searchUnlinkedPatients(String patientName) {
+        List<PatientDocument> patients =
+                patientEsRepository.searchByNameAndNurseIsNull(patientName);
+        Map<PatientDocument, Bed> patientDocumentBedMap = getPatientDocumentBedMap(patients);
+        return PatientConverter.toPatientSearchListResponse(patientDocumentBedMap);
     }
 
     @Override
@@ -113,5 +104,21 @@ public class PatientServiceImpl implements PatientService {
         return patientRepository
                 .findById(patientId)
                 .orElseThrow(() -> new PatientException(ErrorStatus.PATIENT_NOT_FOUND));
+    }
+
+    private void connectNurseToPatient(Patient patient, Nurse nurse) {
+        nurseService.connectPatient(nurse, patient);
+    }
+
+    private Map<PatientDocument, Bed> getPatientDocumentBedMap(List<PatientDocument> patients) {
+        Map<PatientDocument, Bed> patientInfo = new HashMap<>();
+
+        for (PatientDocument patient : patients) {
+            Long bedId = patient.getBedId();
+            Bed bed = bedService.findById(bedId);
+            patientInfo.put(patient, bed);
+        }
+
+        return patientInfo;
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -89,8 +89,7 @@ public class PatientServiceImpl implements PatientService {
 
     @Override
     public PatientSearchListResponse searchUnlinkedPatients(String patientName) {
-        List<PatientDocument> patients =
-                patientEsRepository.searchByNameAndNurseIsNull(patientName);
+        List<PatientDocument> patients = searchPatientsByNameOrAll(patientName);
         Map<PatientDocument, Bed> patientDocumentBedMap = getPatientDocumentBedMap(patients);
         return PatientConverter.toPatientSearchListResponse(patientDocumentBedMap);
     }
@@ -108,6 +107,14 @@ public class PatientServiceImpl implements PatientService {
 
     private void connectNurseToPatient(Patient patient, Nurse nurse) {
         nurseService.connectPatient(nurse, patient);
+    }
+
+    private List<PatientDocument> searchPatientsByNameOrAll(String patientName) {
+
+        if (patientName == null || patientName.isEmpty()) {
+            return patientEsRepository.findAllByNurseIdIsNull();
+        }
+        return patientEsRepository.findByNameAndNurseIdIsNull(patientName);
     }
 
     private Map<PatientDocument, Bed> getPatientDocumentBedMap(List<PatientDocument> patients) {

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/PatientService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/PatientService.java
@@ -12,6 +12,7 @@ import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
 import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.PatientCreateRequest;
+import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
 
 public interface PatientService {
     Map<PatientDocument, Bed> searchPatient(String patientName);
@@ -36,7 +37,7 @@ public interface PatientService {
             CameraSelectRequest cameraSelectRequest,
             Admin admin);
 
-    List<Patient> getUnlinkedPatients(Nurse nurse);
+    PatientSearchListResponse searchUnlinkedPatients(String patientName);
 
     String getPatientNameByCode(String patientCode);
 }

--- a/src/test/java/aurora/carevisionapiserver/ControllerTestSupport.java
+++ b/src/test/java/aurora/carevisionapiserver/ControllerTestSupport.java
@@ -11,15 +11,18 @@ import aurora.carevisionapiserver.domain.admin.repository.AdminRepository;
 import aurora.carevisionapiserver.domain.admin.service.AdminService;
 import aurora.carevisionapiserver.domain.camera.api.NurseCameraController;
 import aurora.carevisionapiserver.domain.camera.service.CameraService;
+import aurora.carevisionapiserver.domain.nurse.api.NurseController;
 import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
 import aurora.carevisionapiserver.domain.nurse.service.NurseService;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
 import aurora.carevisionapiserver.global.auth.util.JWTUtil;
 import aurora.carevisionapiserver.global.common.service.PageService;
+import aurora.carevisionapiserver.global.fcm.service.FcmService;
 
 @WebMvcTest(
         controllers = {
             NurseCameraController.class,
+            NurseController.class,
         })
 public abstract class ControllerTestSupport {
     @Autowired protected MockMvc mockMvc;
@@ -32,4 +35,5 @@ public abstract class ControllerTestSupport {
     @MockBean protected JWTUtil jwtUtil;
     @MockBean protected NurseRepository nurseRepository;
     @MockBean protected AdminRepository adminRepository;
+    @MockBean protected FcmService fcmService;
 }

--- a/src/test/java/aurora/carevisionapiserver/domain/nurse/api/NurseControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/nurse/api/NurseControllerTest.java
@@ -7,8 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,8 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import aurora.carevisionapiserver.ControllerTestSupport;
-import aurora.carevisionapiserver.domain.bed.domain.Bed;
-import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
+import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
 
 class NurseControllerTest extends ControllerTestSupport {
@@ -27,10 +25,11 @@ class NurseControllerTest extends ControllerTestSupport {
     @Test
     void searchUnlinkedPatientList() throws Exception {
         // given
-        Map<PatientDocument, Bed> patientDocumentBedMap = new HashMap<>();
+        PatientSearchListResponse patientSearchListResponse =
+                PatientSearchListResponse.builder().patientList(List.of()).build();
 
         // when
-        when(patientService.searchUnlinkedPatients(any())).thenReturn(patientDocumentBedMap);
+        when(patientService.searchUnlinkedPatients(any())).thenReturn(patientSearchListResponse);
 
         // then
         mockMvc.perform(

--- a/src/test/java/aurora/carevisionapiserver/domain/nurse/api/NurseControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/nurse/api/NurseControllerTest.java
@@ -1,0 +1,46 @@
+package aurora.carevisionapiserver.domain.nurse.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import aurora.carevisionapiserver.ControllerTestSupport;
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
+import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
+
+class NurseControllerTest extends ControllerTestSupport {
+
+    @WithMockUser
+    @DisplayName("간호사와 연결되지 않은 환자 목록을 검색합니다.")
+    @Test
+    void searchUnlinkedPatientList() throws Exception {
+        // given
+        Map<PatientDocument, Bed> patientDocumentBedMap = new HashMap<>();
+
+        // when
+        when(patientService.searchUnlinkedPatients(any())).thenReturn(patientDocumentBedMap);
+
+        // then
+        mockMvc.perform(
+                        get("/api/patients/unlinked/search")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(csrf())
+                                .param("search", "환자명"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(SuccessStatus._OK.getCode()))
+                .andExpect(jsonPath("$.result.patientList").isArray())
+                .andExpect(jsonPath("$.result.count").isNumber());
+    }
+}

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
@@ -1,0 +1,108 @@
+package aurora.carevisionapiserver.domain.patient.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.elasticsearch.DataElasticsearchTest;
+
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+import aurora.carevisionapiserver.domain.hospital.domain.Department;
+import aurora.carevisionapiserver.domain.hospital.domain.Hospital;
+import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
+import aurora.carevisionapiserver.domain.patient.converter.PatientDocumentConverter;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DataElasticsearchTest
+class PatientEsRepositoryTest {
+    @Autowired PatientEsRepository patientEsRepository;
+
+    private List<Patient> patientList;
+
+    @BeforeAll
+    void setup() {
+
+        Department department1 = createDepartment("오로라 과");
+        Bed bed1 = createBed(1L, 2L, 3L, department1);
+        Nurse nurse1 = createNurse(1L, "오로라", department1);
+
+        Patient patient1 = createPatient(1L, "patient0", department1, nurse1, bed1);
+        Patient patient2 = createPatient(2L, "patient1", department1, nurse1, bed1);
+        Patient patient3 = createPatient(3L, "patient2", department1, nurse1, bed1);
+
+        Patient unlinkedPatient1 = createPatient(4L, "patient3", department1, null, bed1);
+        Patient unlinkedPatient2 = createPatient(5L, "patient4", department1, null, bed1);
+
+        patientList = List.of(patient1, patient2, patient3, unlinkedPatient1, unlinkedPatient2);
+
+        patientEsRepository.saveAll(PatientDocumentConverter.toPatientDocumentList(patientList));
+    }
+
+    @AfterEach
+    void tearDown() {
+        patientEsRepository.deleteAll();
+    }
+
+    @DisplayName("환자 이름으로 아직 간호사와 연결되지 않은 환자를 검색한다.")
+    @Test
+    void searchByNameAndNurseIsNull() {
+        // given
+        String patientName = "patient";
+
+        // when
+        List<PatientDocument> response =
+                patientEsRepository.searchByNameAndNurseIsNull(patientName);
+
+        // then
+        assertThat(response)
+                .hasSize(2)
+                .extracting("patientId", "name")
+                .contains(tuple(4L, "patient3"), tuple(5L, "patient4"));
+    }
+
+    private Department createDepartment(String name) {
+        Hospital hospital = createHospital();
+        return Department.builder().hospital(hospital).name(name).build();
+    }
+
+    private Hospital createHospital() {
+        return Hospital.builder().name("hospital").build();
+    }
+
+    private Bed createBed(
+            Long inpatientWardNumber,
+            Long patientRoomNumber,
+            Long bedNumber,
+            Department department) {
+        return Bed.builder()
+                .bedNumber(inpatientWardNumber)
+                .patientRoomNumber(inpatientWardNumber)
+                .inpatientWardNumber(inpatientWardNumber)
+                .department(department)
+                .build();
+    }
+
+    private Nurse createNurse(Long id, String name, Department department) {
+        return Nurse.builder().id(id).name(name).department(department).build();
+    }
+
+    private Patient createPatient(
+            Long id, String name, Department department, Nurse nurse, Bed bed) {
+        return Patient.builder()
+                .id(id)
+                .name(name)
+                .department(department)
+                .nurse(nurse)
+                .bed(bed)
+                .build();
+    }
+}

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
@@ -58,7 +58,7 @@ class PatientEsRepositoryTest extends IntegrationTestSupport {
 
         // when
         List<PatientDocument> response =
-                patientEsRepository.searchByNameAndNurseIsNull(patientName);
+                patientEsRepository.findByNameAndNurseIdIsNull(patientName);
 
         // then
         assertThat(response)

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
@@ -6,13 +6,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.elasticsearch.DataElasticsearchTest;
 
+import aurora.carevisionapiserver.IntegrationTestSupport;
 import aurora.carevisionapiserver.domain.bed.domain.Bed;
 import aurora.carevisionapiserver.domain.hospital.domain.Department;
 import aurora.carevisionapiserver.domain.hospital.domain.Hospital;
@@ -21,30 +20,18 @@ import aurora.carevisionapiserver.domain.patient.converter.PatientDocumentConver
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@DataElasticsearchTest
-class PatientEsRepositoryTest {
+class PatientEsRepositoryTest extends IntegrationTestSupport {
     @Autowired PatientEsRepository patientEsRepository;
 
-    private List<Patient> patientList;
+    private Hospital hospital;
+    private Department department;
+    private Bed bed;
 
-    @BeforeAll
+    @BeforeEach
     void setup() {
-
-        Department department1 = createDepartment("오로라 과");
-        Bed bed1 = createBed(1L, 2L, 3L, department1);
-        Nurse nurse1 = createNurse(1L, "오로라", department1);
-
-        Patient patient1 = createPatient(1L, "patient0", department1, nurse1, bed1);
-        Patient patient2 = createPatient(2L, "patient1", department1, nurse1, bed1);
-        Patient patient3 = createPatient(3L, "patient2", department1, nurse1, bed1);
-
-        Patient unlinkedPatient1 = createPatient(4L, "patient3", department1, null, bed1);
-        Patient unlinkedPatient2 = createPatient(5L, "patient4", department1, null, bed1);
-
-        patientList = List.of(patient1, patient2, patient3, unlinkedPatient1, unlinkedPatient2);
-
-        patientEsRepository.saveAll(PatientDocumentConverter.toPatientDocumentList(patientList));
+        hospital = createHospital();
+        department = createDepartment("오로라 과", hospital);
+        bed = createBed(1L, 1L, 2L, 3L, department);
     }
 
     @AfterEach
@@ -56,6 +43,19 @@ class PatientEsRepositoryTest {
     @Test
     void searchByNameAndNurseIsNull() {
         // given
+        Patient linkedPatient1 = createPatient(1L, "patient1", "A10000", true);
+        Patient linkedPatient2 = createPatient(2L, "patient2", "B10000", true);
+        Patient unlinkedPatient1 = createPatient(3L, "patient3", "D10000", false);
+        Patient unlinkedPatient2 = createPatient(4L, "patient4", "E10000", false);
+
+        patientEsRepository.saveAll(
+                PatientDocumentConverter.toPatientDocumentList(
+                        List.of(
+                                linkedPatient1,
+                                linkedPatient2,
+                                unlinkedPatient1,
+                                unlinkedPatient2)));
+
         String patientName = "patient";
 
         // when
@@ -66,11 +66,10 @@ class PatientEsRepositoryTest {
         assertThat(response)
                 .hasSize(2)
                 .extracting("patientId", "name")
-                .contains(tuple(4L, "patient3"), tuple(5L, "patient4"));
+                .contains(tuple(3L, "patient3"), tuple(4L, "patient4"));
     }
 
-    private Department createDepartment(String name) {
-        Hospital hospital = createHospital();
+    private Department createDepartment(String name, Hospital hospital) {
         return Department.builder().hospital(hospital).name(name).build();
     }
 
@@ -79,30 +78,32 @@ class PatientEsRepositoryTest {
     }
 
     private Bed createBed(
+            Long id,
             Long inpatientWardNumber,
             Long patientRoomNumber,
             Long bedNumber,
             Department department) {
         return Bed.builder()
-                .bedNumber(inpatientWardNumber)
-                .patientRoomNumber(inpatientWardNumber)
+                .id(id)
                 .inpatientWardNumber(inpatientWardNumber)
+                .patientRoomNumber(patientRoomNumber)
+                .bedNumber(bedNumber)
                 .department(department)
+                .build();
+    }
+
+    private Patient createPatient(Long id, String name, String code, boolean linkedToNurse) {
+        return Patient.builder()
+                .id(id)
+                .name(name)
+                .code(code)
+                .department(department)
+                .bed(bed)
+                .nurse(linkedToNurse ? createNurse(id, "오로라", department) : null)
                 .build();
     }
 
     private Nurse createNurse(Long id, String name, Department department) {
         return Nurse.builder().id(id).name(name).department(department).build();
-    }
-
-    private Patient createPatient(
-            Long id, String name, Department department, Nurse nurse, Bed bed) {
-        return Patient.builder()
-                .id(id)
-                .name(name)
-                .department(department)
-                .nurse(nurse)
-                .bed(bed)
-                .build();
     }
 }

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
@@ -41,10 +41,10 @@ class PatientEsRepositoryTest extends IntegrationTestSupport {
     @Test
     void searchByNameAndNurseIsNull() {
         // given
-        Patient linkedPatient1 = createPatient(1L, "patient1", "A10000", true);
-        Patient linkedPatient2 = createPatient(2L, "patient2", "B10000", true);
-        Patient unlinkedPatient1 = createPatient(3L, "patient3", "D10000", false);
-        Patient unlinkedPatient2 = createPatient(4L, "patient4", "E10000", false);
+        Patient linkedPatient1 = createLinkedPatient(1L, "patient1", "A10000");
+        Patient linkedPatient2 = createLinkedPatient(2L, "patient2", "B10000");
+        Patient unlinkedPatient1 = createUnlinkedPatient(3L, "patient3", "D10000");
+        Patient unlinkedPatient2 = createUnlinkedPatient(4L, "patient4", "E10000");
 
         patientEsRepository.saveAll(
                 PatientDocumentConverter.toPatientDocumentList(
@@ -91,14 +91,25 @@ class PatientEsRepositoryTest extends IntegrationTestSupport {
                 .build();
     }
 
-    private Patient createPatient(Long id, String name, String code, boolean linkedToNurse) {
+    private Patient createLinkedPatient(Long id, String name, String code) {
         return Patient.builder()
                 .id(id)
                 .name(name)
                 .code(code)
                 .department(department)
                 .bed(bed)
-                .nurse(linkedToNurse ? createNurse(id, "오로라", department) : null)
+                .nurse(createNurse(id, "오로라", department))
+                .build();
+    }
+
+    private Patient createUnlinkedPatient(Long id, String name, String code) {
+        return Patient.builder()
+                .id(id)
+                .name(name)
+                .code(code)
+                .department(department)
+                .bed(bed)
+                .nurse(null)
                 .build();
     }
 

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/repository/PatientEsRepositoryTest.java
@@ -23,14 +23,12 @@ import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
 class PatientEsRepositoryTest extends IntegrationTestSupport {
     @Autowired PatientEsRepository patientEsRepository;
 
-    private Hospital hospital;
     private Department department;
     private Bed bed;
 
     @BeforeEach
     void setup() {
-        hospital = createHospital();
-        department = createDepartment("오로라 과", hospital);
+        department = createDepartment("오로라 과");
         bed = createBed(1L, 1L, 2L, 3L, department);
     }
 
@@ -69,7 +67,8 @@ class PatientEsRepositoryTest extends IntegrationTestSupport {
                 .contains(tuple(3L, "patient3"), tuple(4L, "patient4"));
     }
 
-    private Department createDepartment(String name, Hospital hospital) {
+    private Department createDepartment(String name) {
+        Hospital hospital = createHospital();
         return Department.builder().hospital(hospital).name(name).build();
     }
 

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
@@ -52,10 +52,10 @@ class PatientServiceTest extends IntegrationTestSupport {
     @Test
     void searchUnlinkedPatients() {
         // given
-        Patient linkedPatient1 = createPatient(1L, "patient1", "A10000", true);
-        Patient linkedPatient2 = createPatient(2L, "patient2", "B10000", true);
-        Patient unlinkedPatient1 = createPatient(3L, "patient3", "D10000", false);
-        Patient unlinkedPatient2 = createPatient(4L, "patient4", "E10000", false);
+        Patient linkedPatient1 = createLinkedPatient(1L, "patient1", "A10000");
+        Patient linkedPatient2 = createLinkedPatient(2L, "patient2", "B10000");
+        Patient unlinkedPatient1 = createUnlinkedPatient(3L, "patient3", "D10000");
+        Patient unlinkedPatient2 = createUnlinkedPatient(4L, "patient4", "E10000");
 
         patientEsRepository.saveAll(
                 PatientDocumentConverter.toPatientDocumentList(
@@ -86,10 +86,10 @@ class PatientServiceTest extends IntegrationTestSupport {
     @Test
     void searchUnlinkedPatientsWhenPatientNameIsEmpty() {
         // given
-        Patient linkedPatient1 = createPatient(1L, "patient1", "A10000", true);
-        Patient linkedPatient2 = createPatient(2L, "patient2", "B10000", true);
-        Patient unlinkedPatient1 = createPatient(3L, "patient3", "D10000", false);
-        Patient unlinkedPatient2 = createPatient(4L, "patient4", "E10000", false);
+        Patient linkedPatient1 = createLinkedPatient(1L, "patient1", "A10000");
+        Patient linkedPatient2 = createLinkedPatient(2L, "patient2", "B10000");
+        Patient unlinkedPatient1 = createUnlinkedPatient(3L, "patient3", "D10000");
+        Patient unlinkedPatient2 = createUnlinkedPatient(4L, "patient4", "E10000");
 
         patientEsRepository.saveAll(
                 PatientDocumentConverter.toPatientDocumentList(
@@ -142,14 +142,25 @@ class PatientServiceTest extends IntegrationTestSupport {
                         .build());
     }
 
-    private Patient createPatient(Long id, String name, String code, boolean linkedToNurse) {
+    private Patient createLinkedPatient(Long id, String name, String code) {
         return Patient.builder()
                 .id(id)
                 .name(name)
                 .code(code)
                 .department(department)
                 .bed(bed)
-                .nurse(linkedToNurse ? createNurse(id, "오로라", department) : null)
+                .nurse(createNurse(id, "오로라", department))
+                .build();
+    }
+
+    private Patient createUnlinkedPatient(Long id, String name, String code) {
+        return Patient.builder()
+                .id(id)
+                .name(name)
+                .code(code)
+                .department(department)
+                .bed(bed)
+                .nurse(null)
                 .build();
     }
 

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
@@ -22,7 +22,6 @@ import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
 import aurora.carevisionapiserver.domain.patient.repository.PatientEsRepository;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS) // BeforeAll 메서드가 static이 아니어도 되도록 설정
 class PatientServiceTest extends IntegrationTestSupport {
 
     @Autowired PatientService patientService;

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
@@ -1,0 +1,129 @@
+package aurora.carevisionapiserver.domain.patient.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+import java.util.List;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import aurora.carevisionapiserver.IntegrationTestSupport;
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+import aurora.carevisionapiserver.domain.bed.repository.BedRepository;
+import aurora.carevisionapiserver.domain.hospital.domain.Department;
+import aurora.carevisionapiserver.domain.hospital.domain.Hospital;
+import aurora.carevisionapiserver.domain.hospital.repository.DepartmentRepository;
+import aurora.carevisionapiserver.domain.hospital.repository.HospitalRepository;
+import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
+import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
+import aurora.carevisionapiserver.domain.patient.converter.PatientDocumentConverter;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
+import aurora.carevisionapiserver.domain.patient.repository.PatientEsRepository;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // BeforeAll 메서드가 static이 아니어도 되도록 설정
+class PatientServiceTest extends IntegrationTestSupport {
+
+    @Autowired PatientService patientService;
+    @Autowired HospitalRepository hospitalRepository;
+    @Autowired DepartmentRepository departmentRepository;
+    @Autowired BedRepository bedRepository;
+    @Autowired NurseRepository nurseRepository;
+    @Autowired PatientEsRepository patientEsRepository;
+
+    private Hospital hospital;
+    private Department department;
+    private Bed bed;
+
+    @BeforeEach
+    void setup() {
+        hospital = createHospital();
+        department = createDepartment("오로라 과", hospital);
+        bed = createBed(1L, 1L, 2L, 3L, department);
+    }
+
+    @AfterEach
+    void tearDown() {
+        patientEsRepository.deleteAll();
+        nurseRepository.deleteAllInBatch();
+        bedRepository.deleteAllInBatch();
+        departmentRepository.deleteAllInBatch();
+        hospitalRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("간호사와 연결되지 않은 환자만 필터링하여 검색한다.")
+    @Test
+    void searchUnlinkedPatients() {
+        // given
+        Patient linkedPatient1 = createPatient(1L, "patient1", "A10000", true);
+        Patient linkedPatient2 = createPatient(2L, "patient2", "B10000", true);
+        Patient unlinkedPatient1 = createPatient(3L, "patient3", "D10000", false);
+        Patient unlinkedPatient2 = createPatient(4L, "patient4", "E10000", false);
+
+        patientEsRepository.saveAll(
+                PatientDocumentConverter.toPatientDocumentList(
+                        List.of(
+                                linkedPatient1,
+                                linkedPatient2,
+                                unlinkedPatient1,
+                                unlinkedPatient2)));
+
+        // when
+        PatientSearchListResponse response = patientService.searchUnlinkedPatients("patient");
+
+        // then
+        assertThat(response.getPatientList())
+                .hasSize(2)
+                .extracting(
+                        "patientName",
+                        "code",
+                        "inpatientWardNumber",
+                        "patientRoomNumber",
+                        "bedNumber")
+                .containsExactlyInAnyOrder(
+                        tuple("patient3", "D10000", 1L, 2L, 3L),
+                        tuple("patient4", "E10000", 1L, 2L, 3L));
+    }
+
+    private Department createDepartment(String name, Hospital hospital) {
+        return departmentRepository.save(
+                Department.builder().hospital(hospital).name(name).build());
+    }
+
+    private Hospital createHospital() {
+        return hospitalRepository.save(Hospital.builder().name("hospital").build());
+    }
+
+    private Bed createBed(
+            Long id,
+            Long inpatientWardNumber,
+            Long patientRoomNumber,
+            Long bedNumber,
+            Department department) {
+        return bedRepository.save(
+                Bed.builder()
+                        .id(id)
+                        .inpatientWardNumber(inpatientWardNumber)
+                        .patientRoomNumber(patientRoomNumber)
+                        .bedNumber(bedNumber)
+                        .department(department)
+                        .build());
+    }
+
+    private Patient createPatient(Long id, String name, String code, boolean linkedToNurse) {
+        return Patient.builder()
+                .id(id)
+                .name(name)
+                .code(code)
+                .department(department)
+                .bed(bed)
+                .nurse(linkedToNurse ? createNurse(id, "오로라", department) : null)
+                .build();
+    }
+
+    private Nurse createNurse(Long id, String name, Department department) {
+        return nurseRepository.save(
+                Nurse.builder().id(id).name(name).department(department).build());
+    }
+}

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
@@ -48,7 +48,7 @@ class PatientServiceTest extends IntegrationTestSupport {
         hospitalRepository.deleteAllInBatch();
     }
 
-    @DisplayName("간호사와 연결되지 않은 환자만 필터링하여 검색한다.")
+    @DisplayName("환자명을 입력받아 간호사와 연결되지 않은 환자만 검색한다.")
     @Test
     void searchUnlinkedPatients() {
         // given
@@ -67,6 +67,40 @@ class PatientServiceTest extends IntegrationTestSupport {
 
         // when
         PatientSearchListResponse response = patientService.searchUnlinkedPatients("patient");
+
+        // then
+        assertThat(response.getPatientList())
+                .hasSize(2)
+                .extracting(
+                        "patientName",
+                        "code",
+                        "inpatientWardNumber",
+                        "patientRoomNumber",
+                        "bedNumber")
+                .containsExactlyInAnyOrder(
+                        tuple("patient3", "D10000", 1L, 2L, 3L),
+                        tuple("patient4", "E10000", 1L, 2L, 3L));
+    }
+
+    @DisplayName("검색어를 입력하지 않았을 때에는 간호사와 연결되지 않은 모든 환자가 검색된다.")
+    @Test
+    void searchUnlinkedPatientsWhenPatientNameIsEmpty() {
+        // given
+        Patient linkedPatient1 = createPatient(1L, "patient1", "A10000", true);
+        Patient linkedPatient2 = createPatient(2L, "patient2", "B10000", true);
+        Patient unlinkedPatient1 = createPatient(3L, "patient3", "D10000", false);
+        Patient unlinkedPatient2 = createPatient(4L, "patient4", "E10000", false);
+
+        patientEsRepository.saveAll(
+                PatientDocumentConverter.toPatientDocumentList(
+                        List.of(
+                                linkedPatient1,
+                                linkedPatient2,
+                                unlinkedPatient1,
+                                unlinkedPatient2)));
+
+        // when
+        PatientSearchListResponse response = patientService.searchUnlinkedPatients("");
 
         // then
         assertThat(response.getPatientList())

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceTest.java
@@ -31,15 +31,12 @@ class PatientServiceTest extends IntegrationTestSupport {
     @Autowired BedRepository bedRepository;
     @Autowired NurseRepository nurseRepository;
     @Autowired PatientEsRepository patientEsRepository;
-
-    private Hospital hospital;
     private Department department;
     private Bed bed;
 
     @BeforeEach
     void setup() {
-        hospital = createHospital();
-        department = createDepartment("오로라 과", hospital);
+        department = createDepartment("오로라 과");
         bed = createBed(1L, 1L, 2L, 3L, department);
     }
 
@@ -86,7 +83,8 @@ class PatientServiceTest extends IntegrationTestSupport {
                         tuple("patient4", "E10000", 1L, 2L, 3L));
     }
 
-    private Department createDepartment(String name, Hospital hospital) {
+    private Department createDepartment(String name) {
+        Hospital hospital = createHospital();
         return departmentRepository.save(
                 Department.builder().hospital(hospital).name(name).build());
     }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #112 

## 📌 개요
- 연결되지 않은 환자 목록 조회 API에 대한 리포지토리, 서비스, 컨트롤러 테스트를 진행하고 기능을 구현하였습니다.

## 🔁 변경 사항
### 주요 변경 사항
- 원래 연결되지 않은 환자 목록을 조회하는 API를 검색 API로 통합했습니다.
  - 만약 검색할 환자명이 `null`이거나 `""`일 경우 연결되지 않은 `모든` 환자 목록을 조회합니다.
- 연결되지 않은 환자를 필터링하기 위해 PatientDocument에 `nurseId` 필드를 추가했습니다.

- `nurseId`가 `null`인 경우, Elasticsearch에서는 **nurseId 필드가 존재하지 않도록 처리**되기 때문에 이를 대신할 특정 값으로 `-1`을 넣어주었습니다. 따라서 연결되지 않은 환자를 조회할 때 nurseId 필드가 `-1`로 지정된 도큐먼트를 가져오도록 리포지토리 메서드를 작성했습니다. 
### 사소한 변경사항
- 간호사 검색 API에서 관리자 인증이 누락된 부분이 있어서 추가했습니다.

- PatientDocumentConverter가 따로 존재하므로 toNurseDocument 메서드도 NurseDocumentConverter를 생성해 옮겨주었습니다.


## 📸 스크린샷
<img width="916" alt="image" src="https://github.com/user-attachments/assets/dd21e788-e032-4a3d-a642-b52f3adf743c" />
<img width="929" alt="image" src="https://github.com/user-attachments/assets/a6b42bdd-b829-4eac-b1df-04552c2b4a41" />

<img width="917" alt="image" src="https://github.com/user-attachments/assets/121c6491-6e4f-4673-a94f-290d444977a7" />


## 👀 기타 더 이야기해볼 점
- DB에 존재하는 데이터를 Elasticsearch에 동기화하도록하는 로직 및 Elasticsearch 매핑 정의 세팅 관련한 코드는 PR이 무거워질 것 같아 다른 PR로 올리겠습니다!

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
