### PR TITLE
[feat] Elasticsearch와 DB 동기화 API 작성 및 인덱스 매핑 셸 스크립트 작성

### DIFF
--- a/scripts/init_elasticsearch.sh
+++ b/scripts/init_elasticsearch.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# ⚠️ 인덱스 삭제 후 다시 생성 ⚠️
+
+# Elasticsearch 서버 정보
+ES_HOST="http://localhost:9200"
+
+# 인덱스 목록
+INDICES=("patient" "nurse")
+
+# 매핑 파일 경로
+RESOURCE_DIR="../src/main/resources/elasticsearch"
+PATIENT_MAPPING_FILE="$RESOURCE_DIR/patient-mapping.json"
+NURSE_MAPPING_FILE="$RESOURCE_DIR/nurse-mapping.json"
+
+# 인덱스 삭제 함수
+delete_index() {
+  local index_name=$1
+  echo "🗑 인덱스 삭제 중: $index_name"
+  curl -X DELETE "$ES_HOST/$index_name" -s -o /dev/null
+  echo "✅ $index_name 인덱스가 삭제되었습니다."
+}
+
+# 인덱스 생성 함수
+create_index() {
+  local index_name=$1
+  local mapping_file=$2
+
+  if [ ! -f "$mapping_file" ]; then
+    echo "❌ 매핑 파일을 찾을 수 없습니다: $mapping_file"
+    exit 1
+  fi
+
+  local mapping=$(cat "$mapping_file")
+
+  echo "📌 인덱스 생성 중: $index_name"
+  curl -X PUT "$ES_HOST/$index_name" -H "Content-Type: application/json" -d "$mapping"
+  echo -e "\n✅ $index_name 인덱스 생성되었습니다."
+}
+
+# 메인 로직
+for index in "${INDICES[@]}"; do
+  delete_index "$index"
+  if [ "$index" == "patient" ]; then
+    create_index "$index" "$PATIENT_MAPPING_FILE"
+  elif [ "$index" == "nurse" ]; then
+    create_index "$index" "$NURSE_MAPPING_FILE"
+  fi
+done

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/converter/NurseDocumentConverter.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/converter/NurseDocumentConverter.java
@@ -1,9 +1,15 @@
 package aurora.carevisionapiserver.domain.nurse.converter;
 
+import java.util.List;
+
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.domain.NurseDocument;
 
 public class NurseDocumentConverter {
+    public static List<NurseDocument> toNurseDocumentList(List<Nurse> nurses) {
+        return nurses.stream().map(NurseDocumentConverter::toNurseDocument).toList();
+    }
+
     public static NurseDocument toNurseDocument(Nurse nurse) {
         return NurseDocument.builder().name(nurse.getName()).username(nurse.getUsername()).build();
     }

--- a/src/main/java/aurora/carevisionapiserver/global/config/SecurityConfig.java
+++ b/src/main/java/aurora/carevisionapiserver/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         "/api/admin/hospitals",
         "/api/login",
         "/api/fcm/**",
+        "/api/internal/**",
         "/health",
         "/error",
         "/swagger-ui/**",

--- a/src/main/java/aurora/carevisionapiserver/global/elasticsearch/api/ElasticSearchSyncController.java
+++ b/src/main/java/aurora/carevisionapiserver/global/elasticsearch/api/ElasticSearchSyncController.java
@@ -1,0 +1,34 @@
+package aurora.carevisionapiserver.global.elasticsearch.api;
+
+import java.util.Collections;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import aurora.carevisionapiserver.global.elasticsearch.service.ElasticSearchSyncService;
+import aurora.carevisionapiserver.global.response.BaseResponse;
+import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "X_ElasticSearch 🔍", description = "ElasticSearch 데이터 동기화 (내부 시스템 전용)")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/internal/elasticsearch")
+public class ElasticSearchSyncController {
+
+    private final ElasticSearchSyncService elasticSearchSyncService;
+
+    @PostMapping("/patients/sync")
+    public BaseResponse<Object> syncPatients() {
+        elasticSearchSyncService.syncPatientDatabaseToElasticsearch();
+        return BaseResponse.of(SuccessStatus._OK, Collections.emptyMap());
+    }
+
+    @PostMapping("/nurses/sync")
+    public BaseResponse<Object> syncNurses() {
+        elasticSearchSyncService.syncNurseDatabaseToElasticsearch();
+        return BaseResponse.of(SuccessStatus._OK, Collections.emptyMap());
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/global/elasticsearch/service/ElasticSearchSyncService.java
+++ b/src/main/java/aurora/carevisionapiserver/global/elasticsearch/service/ElasticSearchSyncService.java
@@ -1,0 +1,7 @@
+package aurora.carevisionapiserver.global.elasticsearch.service;
+
+public interface ElasticSearchSyncService {
+    void syncPatientDatabaseToElasticsearch();
+
+    void syncNurseDatabaseToElasticsearch();
+}

--- a/src/main/java/aurora/carevisionapiserver/global/elasticsearch/service/Impl/ElasticSearchSyncSyncServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/global/elasticsearch/service/Impl/ElasticSearchSyncSyncServiceImpl.java
@@ -1,0 +1,49 @@
+package aurora.carevisionapiserver.global.elasticsearch.service.Impl;
+
+import java.util.List;
+
+import jakarta.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import aurora.carevisionapiserver.domain.nurse.converter.NurseDocumentConverter;
+import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
+import aurora.carevisionapiserver.domain.nurse.domain.NurseDocument;
+import aurora.carevisionapiserver.domain.nurse.repository.NurseEsRepository;
+import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
+import aurora.carevisionapiserver.domain.patient.converter.PatientDocumentConverter;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
+import aurora.carevisionapiserver.domain.patient.repository.PatientEsRepository;
+import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
+import aurora.carevisionapiserver.global.elasticsearch.service.ElasticSearchSyncService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ElasticSearchSyncSyncServiceImpl implements ElasticSearchSyncService {
+
+    private final PatientRepository patientRepository;
+    private final PatientEsRepository patientESRepository;
+
+    private final NurseRepository nurseRepository;
+    private final NurseEsRepository nurseEsRepository;
+
+    @Override
+    @Transactional
+    public void syncPatientDatabaseToElasticsearch() {
+        patientESRepository.deleteAll();
+        List<Patient> patients = patientRepository.findAll();
+        List<PatientDocument> esDocuments =
+                PatientDocumentConverter.toPatientDocumentList(patients);
+        patientESRepository.saveAll(esDocuments);
+    }
+
+    @Override
+    public void syncNurseDatabaseToElasticsearch() {
+        nurseEsRepository.deleteAll();
+        List<Nurse> nurses = nurseRepository.findAll();
+        List<NurseDocument> esDocuments = NurseDocumentConverter.toNurseDocumentList(nurses);
+        nurseEsRepository.saveAll(esDocuments);
+    }
+}

--- a/src/main/resources/elasticsearch/nurse-mapping.json
+++ b/src/main/resources/elasticsearch/nurse-mapping.json
@@ -1,0 +1,31 @@
+{
+  "settings": {
+    "analysis": {
+      "tokenizer": {
+        "my_ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 2,
+          "max_gram": 3,
+          "token_chars": ["letter", "digit"]
+        }
+      },
+      "analyzer": {
+        "my_ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "my_ngram_tokenizer"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "text",
+        "analyzer": "my_ngram_analyzer"
+      },
+      "username": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/src/main/resources/elasticsearch/patient-mapping.json
+++ b/src/main/resources/elasticsearch/patient-mapping.json
@@ -1,0 +1,34 @@
+{
+  "settings": {
+    "analysis": {
+      "tokenizer": {
+        "my_ngram_tokenizer": {
+          "type": "ngram",
+          "min_gram": 2,
+          "max_gram": 3,
+          "token_chars": ["letter", "digit"]
+        }
+      },
+      "analyzer": {
+        "my_ngram_analyzer": {
+          "type": "custom",
+          "tokenizer": "my_ngram_tokenizer"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "text",
+        "analyzer": "my_ngram_analyzer"
+      },
+      "patientId": {
+        "type": "long"
+      },
+      "nurseId": {
+        "type": "long"
+      }
+    }
+  }
+}

--- a/src/test/java/aurora/carevisionapiserver/global/elasticsearch/service/ElasticSearchSyncServiceTest.java
+++ b/src/test/java/aurora/carevisionapiserver/global/elasticsearch/service/ElasticSearchSyncServiceTest.java
@@ -1,0 +1,159 @@
+package aurora.carevisionapiserver.global.elasticsearch.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import aurora.carevisionapiserver.IntegrationTestSupport;
+import aurora.carevisionapiserver.domain.bed.domain.Bed;
+import aurora.carevisionapiserver.domain.bed.repository.BedRepository;
+import aurora.carevisionapiserver.domain.hospital.domain.Department;
+import aurora.carevisionapiserver.domain.hospital.domain.Hospital;
+import aurora.carevisionapiserver.domain.hospital.repository.DepartmentRepository;
+import aurora.carevisionapiserver.domain.hospital.repository.HospitalRepository;
+import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
+import aurora.carevisionapiserver.domain.nurse.domain.NurseDocument;
+import aurora.carevisionapiserver.domain.nurse.repository.NurseEsRepository;
+import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
+import aurora.carevisionapiserver.domain.patient.domain.Patient;
+import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
+import aurora.carevisionapiserver.domain.patient.repository.PatientEsRepository;
+import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
+
+class ElasticSearchSyncServiceTest extends IntegrationTestSupport {
+
+    @Autowired ElasticSearchSyncService elasticSearchSyncService;
+
+    @Autowired HospitalRepository hospitalRepository;
+    @Autowired DepartmentRepository departmentRepository;
+    @Autowired BedRepository bedRepository;
+    @Autowired NurseRepository nurseRepository;
+    @Autowired PatientRepository patientRepository;
+
+    @Autowired PatientEsRepository patientEsRepository;
+    @Autowired NurseEsRepository nurseEsRepository;
+
+    private Department department;
+
+    @BeforeEach
+    void setup() {
+        department = createDepartment("오로라 과");
+    }
+
+    @AfterEach
+    void tearDown() {
+        patientEsRepository.deleteAll();
+        nurseEsRepository.deleteAll();
+        patientRepository.deleteAllInBatch();
+        nurseRepository.deleteAllInBatch();
+        bedRepository.deleteAllInBatch();
+        departmentRepository.deleteAllInBatch();
+        hospitalRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("환자 데이터 Elasticsearch와 동기화")
+    @Test
+    void syncPatientDatabaseToElasticsearch() {
+        // given
+        createPatient(1L, "patient1", "A10000");
+        createPatient(2L, "patient2", "B10000");
+        createPatient(3L, "patient3", "C10000");
+
+        // when
+        elasticSearchSyncService.syncPatientDatabaseToElasticsearch();
+
+        // then
+        Iterable<PatientDocument> patientDocuments = patientEsRepository.findAll();
+        assertThat(patientDocuments)
+                .hasSize(3)
+                .extracting(
+                        "patientName",
+                        "code",
+                        "inpatientWardNumber",
+                        "patientRoomNumber",
+                        "bedNumber")
+                .containsExactlyInAnyOrder(
+                        tuple("patient1", "A10000", 1L, 2L, 3L),
+                        tuple("patient2", "B10000", 1L, 2L, 3L),
+                        tuple("patient3", "C10000", 1L, 2L, 3L));
+    }
+
+    @DisplayName("간호사 데이터 Elasticsearch와 동기화")
+    @Test
+    void syncNurseDatabaseToElasticsearch() {
+        // given
+        createNurse(1L, "nurse1", "aurora1");
+        createNurse(2L, "nurse2", "aurora2");
+        createNurse(3L, "nurse3", "aurora3");
+
+        // when
+        elasticSearchSyncService.syncNurseDatabaseToElasticsearch();
+
+        // then
+        Iterable<NurseDocument> nurseDocuments = nurseEsRepository.findAll();
+        assertThat(nurseDocuments)
+                .hasSize(3)
+                .extracting("name", "username")
+                .containsExactlyInAnyOrder(
+                        tuple("nurse1", "aurora1"),
+                        tuple("nurse2", "aurora2"),
+                        tuple("nurse3", "aurora3"));
+    }
+
+    private Department createDepartment(String name) {
+        Hospital hospital = createHospital();
+        return departmentRepository.save(
+                Department.builder().hospital(hospital).name(name).build());
+    }
+
+    private Hospital createHospital() {
+        return hospitalRepository.save(Hospital.builder().name("hospital").build());
+    }
+
+    private Bed createBed(
+            Long id,
+            Long inpatientWardNumber,
+            Long patientRoomNumber,
+            Long bedNumber,
+            Department department) {
+        return bedRepository.save(
+                Bed.builder()
+                        .id(id)
+                        .inpatientWardNumber(inpatientWardNumber)
+                        .patientRoomNumber(patientRoomNumber)
+                        .bedNumber(bedNumber)
+                        .department(department)
+                        .build());
+    }
+
+    private void createPatient(Long id, String name, String code) {
+        Bed bed = createBed(1L, 1L, 2L, 3L, department);
+        Nurse nurse = createNurse(id, "nurse1", "aurora1");
+        Patient patient =
+                patientRepository.save(
+                        Patient.builder()
+                                .id(id)
+                                .name(name)
+                                .code(code)
+                                .department(department)
+                                .bed(bed)
+                                .nurse(nurse)
+                                .build());
+        bed.registerPatient(patient);
+    }
+
+    private Nurse createNurse(Long id, String name, String username) {
+        return nurseRepository.save(
+                Nurse.builder()
+                        .id(id)
+                        .name(name)
+                        .username(username)
+                        .department(department)
+                        .build());
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #192 

## 📌 개요
- Elasticsearch와 DB를 동기화하는 API를 작성하고, Elasticsearch 인덱스를 매핑하는 셸 스크립트를 추가했습니다.

## 🔁 변경 사항
- Elasticsearch와 DB 동기화 API 작성 & 테스트
   - 임의로 더미 데이터를 삽입하는 경우에는 Elasticsearch에 인덱스가 저장되지 않는 문제 & Elasticsearch 도입 전 데이터에 대한 인덱스는 아직 존재하지 않을 수 있는 문제를 방지하기 위해 작성했습니다.
    - 기존 DB에 있는 데이터를 Elasticsearch로 전송합니다.

- Elasticsearch 인덱스 매핑 셸 스크립트 작성
  - `@PostConstruct`를 사용하여 애플리케이션 시작할 때 인덱스를 매핑하는 자바 코드를 작성할까도 만들까 고민했으나 인덱스 매핑은 한 번만 이루어지면 되므로 애플리케이션의 코드와 독립적으로 실행하는 게 나을 것 같아 셸 스크립트로 작성했습니다. 인텔리제이에서 실행하거나 다음 명령어로 실행할 수 있습니다! 이 명령어 실행 후 필요하다면 데이터 동기화 API 한 번 호출하면 됩니다!
```
chmod +x init_elasticsearch.sh
./scripts/init_elasticsearch.sh
```

## 📸 스크린샷
스크립트를 실행하면 다음과 같은 로그를 확인할 수 있습니다!
<img width="628" alt="image" src="https://github.com/user-attachments/assets/ee5c2c36-a1db-4f3c-a386-231b9062a918" />


## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
