### PR TITLE
[feat] 카메라 조회할때 필요한 마지막 인덱스 값 조회 기능 구현

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
@@ -45,10 +45,10 @@ public class CameraServiceImpl implements CameraService {
 
     @Override
     public Slice<Camera> getAllCameraInfo(Admin admin, PageForCameraRequest request) {
-        Long lastIdx = CameraIdUtil.parseLongId(request.cameraId());
+        Long lastIdx = CameraIdUtil.parseLongId(request.getCameraId());
 
         return cameraRepository.findAllCamerasSortedByBed(
-                admin.getDepartment(), lastIdx, request.size());
+                admin.getDepartment(), lastIdx, request.getSize());
     }
 
     public List<Camera> getCameraInfoUnlinkedToPatient(User user) {
@@ -72,7 +72,7 @@ public class CameraServiceImpl implements CameraService {
     public Slice<VideoInfoResponse> getSavedVideoInfos(Long patientId, PageRequest request) {
         Patient patient = patientService.getPatient(patientId);
         Slice<Video> videos =
-                videoRepository.findByPatient(patient, request.lastIdx(), request.size());
+                videoRepository.findByPatient(patient, request.getLastIdx(), request.getSize());
         List<VideoInfoResponse> videoInfoResponses = getVideoInfoListResponses(videos);
         return new SliceImpl<>(videoInfoResponses, videos.getPageable(), videos.hasNext());
     }

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/service/Impl/NurseServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/service/Impl/NurseServiceImpl.java
@@ -66,7 +66,8 @@ public class NurseServiceImpl implements NurseService {
 
     @Override
     public Slice<Nurse> getActiveNurses(Admin admin, PageRequest request) {
-        return nurseRepository.findActiveNursesByAdmin(admin, request.lastIdx(), request.size());
+        return nurseRepository.findActiveNursesByAdmin(
+                admin, request.getLastIdx(), request.getSize());
     }
 
     @Override

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -45,12 +45,12 @@ public class PatientServiceImpl implements PatientService {
 
     @Override
     public Slice<Patient> getPatients(Admin admin, PageRequest request) {
-        return patientRepository.findPatientByAdmin(admin, request.lastIdx(), request.size());
+        return patientRepository.findPatientByAdmin(admin, request.getLastIdx(), request.getSize());
     }
 
     @Override
     public Slice<Patient> getPatientSlice(Nurse nurse, PageRequest request) {
-        return patientRepository.findPatientByNurse(nurse, request.lastIdx(), request.size());
+        return patientRepository.findPatientByNurse(nurse, request.getLastIdx(), request.getSize());
     }
 
     @Override

--- a/src/main/java/aurora/carevisionapiserver/global/common/dto/request/BasePageRequest.java
+++ b/src/main/java/aurora/carevisionapiserver/global/common/dto/request/BasePageRequest.java
@@ -1,0 +1,25 @@
+package aurora.carevisionapiserver.global.common.dto.request;
+
+public abstract class BasePageRequest<T> {
+    private static final int DEFAULT_SIZE = 8;
+
+    protected final T identifier;
+    protected final int size;
+
+    public BasePageRequest(T identifier, int size) {
+        this.identifier = identifier;
+        this.size = getValidSize(size);
+    }
+
+    public BasePageRequest(T identifier) {
+        this(identifier, DEFAULT_SIZE);
+    }
+
+    private int getValidSize(int size) {
+        return (size > 0) ? size : DEFAULT_SIZE;
+    }
+
+    public int getSize() {
+        return this.size;
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/global/common/dto/request/PageForCameraRequest.java
+++ b/src/main/java/aurora/carevisionapiserver/global/common/dto/request/PageForCameraRequest.java
@@ -1,8 +1,15 @@
 package aurora.carevisionapiserver.global.common.dto.request;
 
-public record PageForCameraRequest(String cameraId, int size) {
+public final class PageForCameraRequest extends BasePageRequest<String> {
+    public PageForCameraRequest(String cameraId) {
+        super(cameraId);
+    }
+
     public PageForCameraRequest(String cameraId, int size) {
-        this.cameraId = cameraId;
-        this.size = (size > 0) ? size : 8;
+        super(cameraId, size);
+    }
+
+    public String getCameraId() {
+        return super.identifier;
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/common/dto/request/PageRequest.java
+++ b/src/main/java/aurora/carevisionapiserver/global/common/dto/request/PageRequest.java
@@ -1,8 +1,15 @@
 package aurora.carevisionapiserver.global.common.dto.request;
 
-public record PageRequest(Long lastIdx, int size) {
+public final class PageRequest extends BasePageRequest<Long> {
+    public PageRequest(Long lastIdx) {
+        super(lastIdx);
+    }
+
     public PageRequest(Long lastIdx, int size) {
-        this.lastIdx = lastIdx;
-        this.size = (size > 0) ? size : 8;
+        super(lastIdx, size);
+    }
+
+    public Long getLastIdx() {
+        return super.identifier;
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/common/service/impl/PageServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/global/common/service/impl/PageServiceImpl.java
@@ -17,7 +17,6 @@ public class PageServiceImpl implements PageService {
 
     @Override
     public String getNextCursorForCameras(List<Camera> cameras) {
-
-        return null;
+        return cameras.get(cameras.size() - 1).getId();
     }
 }

--- a/src/test/java/aurora/carevisionapiserver/global/common/dto/request/PageForCameraRequestTest.java
+++ b/src/test/java/aurora/carevisionapiserver/global/common/dto/request/PageForCameraRequestTest.java
@@ -1,0 +1,20 @@
+package aurora.carevisionapiserver.global.common.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PageForCameraRequestTest {
+    @DisplayName("요청된 size가 null일 경우 size는 8로 설정된다.")
+    @Test
+    void PageForCameraRequestTest() {
+        String cameraId = "CAM1";
+
+        // when
+        PageForCameraRequest request = new PageForCameraRequest(cameraId);
+
+        // then
+        assertThat(request.getSize()).isEqualTo(8);
+    }
+}

--- a/src/test/java/aurora/carevisionapiserver/global/common/dto/request/PageRequestTest.java
+++ b/src/test/java/aurora/carevisionapiserver/global/common/dto/request/PageRequestTest.java
@@ -1,0 +1,21 @@
+package aurora.carevisionapiserver.global.common.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PageRequestTest {
+    @DisplayName("요청된 size가 null일 경우 size는 8로 설정된다.")
+    @Test
+    void PageRequest() {
+        // given
+        Long lastIdx = 1L;
+
+        // when
+        PageRequest request = new PageRequest(lastIdx);
+
+        // then
+        assertThat(request.getSize()).isEqualTo(8);
+    }
+}

--- a/src/test/java/aurora/carevisionapiserver/global/common/service/impl/PageServiceImplTest.java
+++ b/src/test/java/aurora/carevisionapiserver/global/common/service/impl/PageServiceImplTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import aurora.carevisionapiserver.IntegrationTestSupport;
 import aurora.carevisionapiserver.domain.bed.repository.BedRepository;
+import aurora.carevisionapiserver.domain.camera.domain.Camera;
 import aurora.carevisionapiserver.domain.hospital.domain.Department;
 import aurora.carevisionapiserver.domain.hospital.domain.Hospital;
 import aurora.carevisionapiserver.domain.hospital.repository.DepartmentRepository;
@@ -53,6 +54,24 @@ class PageServiceImplTest extends IntegrationTestSupport {
 
         // then
         assertThat(nextCursor).isEqualTo(3L);
+    }
+
+    @DisplayName("주어진 리스트에서 마지막 카메라 엔티티의 ID를 반환한다.")
+    @Test
+    void getNextCursorForCameras() {
+        // given
+        Camera camera1 = createCamera("CAM1");
+        Camera camera2 = createCamera("CAM2");
+
+        // when
+        String nextCursor = pageService.getNextCursorForCameras(List.of(camera1, camera2));
+
+        // then
+        assertThat(nextCursor).isEqualTo(camera2.getId());
+    }
+
+    private Camera createCamera(String id) {
+        return Camera.builder().id(id).build();
     }
 
     private Department createDepartment() {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #198 

## 📌 개요
-  카메라 조회할때 필요한 마지막 인덱스 값 조회 기능 구현했습니다!
`return null;`로 되어있더라구요.. 왜 이제야 발견한거지...
- 페이지네이션 요청 DTO 모듈화했고, 기존에는 lastIdx,size를 둘다 입력받아야 했었는데 size는 입력하지 않아도 디폴트 값이 설정되도록 해뒀습니다!

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
