### PR TITLE
[refactor] DTO에서 요청 파라미터로 페이지 처리 값 입력 받도록 수정

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/camera/api/AdminCameraController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/api/AdminCameraController.java
@@ -1,9 +1,10 @@
 package aurora.carevisionapiserver.domain.camera.api;
 
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import aurora.carevisionapiserver.domain.admin.domain.Admin;
@@ -11,7 +12,6 @@ import aurora.carevisionapiserver.domain.camera.converter.CameraConverter;
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.CameraInfoPageResponse;
 import aurora.carevisionapiserver.domain.camera.service.CameraService;
-import aurora.carevisionapiserver.global.common.dto.request.PageForCameraRequest;
 import aurora.carevisionapiserver.global.common.service.PageService;
 import aurora.carevisionapiserver.global.response.BaseResponse;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
@@ -38,8 +38,9 @@ public class AdminCameraController {
     @GetMapping("")
     public BaseResponse<CameraInfoPageResponse> getCameras(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
-            @RequestBody PageForCameraRequest request) {
-        Slice<Camera> cameras = cameraService.getAllCameraInfo(admin, request);
+            @RequestParam(value = "cameraId") String cameraId,
+            @PageableDefault(size = 8, sort = "id") @RequestParam(value = "size") int size) {
+        Slice<Camera> cameras = cameraService.getAllCameraInfo(admin, cameraId, size);
         return BaseResponse.of(
                 SuccessStatus._OK,
                 CameraConverter.toCameraInfoPageResponse(

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraController.java
@@ -3,10 +3,11 @@ package aurora.carevisionapiserver.domain.camera.api;
 import java.util.Map;
 
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import aurora.carevisionapiserver.domain.camera.converter.CameraConverter;
@@ -20,7 +21,6 @@ import aurora.carevisionapiserver.domain.camera.service.CameraService;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.common.service.PageService;
 import aurora.carevisionapiserver.global.response.BaseResponse;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
@@ -65,8 +65,9 @@ public class NurseCameraController {
     @GetMapping("/streaming")
     public BaseResponse<StreamingPageResponse> getStreamingInfoList(
             @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
-            @RequestBody PageRequest request) {
-        Slice<Patient> patients = patientService.getPatientSlice(nurse, request);
+            @RequestParam(value = "lastIdx") Long lastIdx,
+            @PageableDefault(size = 8, sort = "id") @RequestParam(value = "size") int size) {
+        Slice<Patient> patients = patientService.getPatientSlice(nurse, lastIdx, size);
         Map<Patient, String> streamingInfo = cameraService.getStreamingInfo(patients.getContent());
 
         return BaseResponse.of(
@@ -88,8 +89,10 @@ public class NurseCameraController {
     public BaseResponse<VideoInfoPageResponse> getSavedVideoInfos(
             @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
             @PathVariable(name = "patientId") Long patientId,
-            @RequestBody PageRequest request) {
-        Slice<VideoInfoResponse> videoInfo = cameraService.getSavedVideoInfos(patientId, request);
+            @RequestParam(value = "lastIdx") Long lastIdx,
+            @PageableDefault(size = 8, sort = "id") @RequestParam(value = "size") int size) {
+        Slice<VideoInfoResponse> videoInfo =
+                cameraService.getSavedVideoInfos(patientId, lastIdx, size);
         return BaseResponse.of(
                 SuccessStatus._OK,
                 CameraConverter.toVideoInfoPageResponse(

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/repository/CameraRepository.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/repository/CameraRepository.java
@@ -1,6 +1,5 @@
 package aurora.carevisionapiserver.domain.camera.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,6 +12,4 @@ import aurora.carevisionapiserver.domain.patient.domain.Patient;
 public interface CameraRepository extends JpaRepository<Camera, String>, CustomCameraRepository {
     @Query("SELECT c FROM Camera c JOIN c.bed b WHERE b.patient = :patient")
     Optional<Camera> findByPatient(@Param("patient") Patient patient);
-
-    List<Camera> findByIdIn(List<String> ids);
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/CameraService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/CameraService.java
@@ -11,11 +11,9 @@ import aurora.carevisionapiserver.domain.camera.domain.Video;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.global.auth.domain.User;
-import aurora.carevisionapiserver.global.common.dto.request.PageForCameraRequest;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 
 public interface CameraService {
-    Slice<Camera> getAllCameraInfo(Admin admin, PageForCameraRequest request);
+    Slice<Camera> getAllCameraInfo(Admin admin, String cameraId, int size);
 
     List<Camera> getCameraInfoUnlinkedToPatient(User user);
 
@@ -23,7 +21,7 @@ public interface CameraService {
 
     Map<Patient, String> getStreamingInfo(List<Patient> patients);
 
-    Slice<VideoInfoResponse> getSavedVideoInfos(Long patientId, PageRequest request);
+    Slice<VideoInfoResponse> getSavedVideoInfos(Long patientId, Long lastIdx, int size);
 
     Video getSavedVideo(Long videoId);
 

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import jakarta.transaction.Transactional;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -26,15 +24,12 @@ import aurora.carevisionapiserver.domain.camera.service.CameraService;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
 import aurora.carevisionapiserver.global.auth.domain.User;
-import aurora.carevisionapiserver.global.common.dto.request.PageForCameraRequest;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.infra.aws.S3Service;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class CameraServiceImpl implements CameraService {
     private static final int CAMERA_IP_INDEX = 0;
     private static final int CAMERA_PW_INDEX = 1;
@@ -49,12 +44,12 @@ public class CameraServiceImpl implements CameraService {
     private final PatientService patientService;
 
     @Override
-    public Slice<Camera> getAllCameraInfo(Admin admin, PageForCameraRequest request) {
-        Camera camera = getCameraById(request.getCameraId());
-        List<Bed> beds = getNextBeds(admin, camera, request.getSize());
+    public Slice<Camera> getAllCameraInfo(Admin admin, String cameraId, int size) {
+        Camera camera = getCameraById(cameraId);
+        List<Bed> beds = getNextBeds(admin, camera, size);
         List<Camera> cameras = getCamerasByBeds(beds);
 
-        return createCameraSlice(cameras, request.getSize());
+        return createCameraSlice(cameras, size);
     }
 
     private Slice<Camera> createCameraSlice(List<Camera> cameras, int size) {
@@ -100,10 +95,9 @@ public class CameraServiceImpl implements CameraService {
     }
 
     @Override
-    public Slice<VideoInfoResponse> getSavedVideoInfos(Long patientId, PageRequest request) {
+    public Slice<VideoInfoResponse> getSavedVideoInfos(Long patientId, Long lastIdx, int size) {
         Patient patient = patientService.getPatient(patientId);
-        Slice<Video> videos =
-                videoRepository.findByPatient(patient, request.getLastIdx(), request.getSize());
+        Slice<Video> videos = videoRepository.findByPatient(patient, lastIdx, size);
         List<VideoInfoResponse> videoInfoResponses = getVideoInfoListResponses(videos);
         return new SliceImpl<>(videoInfoResponses, videos.getPageable(), videos.hasNext());
     }

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
@@ -61,10 +61,9 @@ public class CameraServiceImpl implements CameraService {
     }
 
     private List<Camera> getCamerasByBeds(List<Bed> beds) {
-        List<String> cameraIds =
-                beds.stream().map(bed -> bed.getCamera().getId()).collect(Collectors.toList());
+        List<String> cameraIds = beds.stream().map(bed -> bed.getCamera().getId()).toList();
 
-        return cameraRepository.findByIdIn(cameraIds);
+        return cameraIds.stream().map(id -> getCameraById(id)).collect(Collectors.toList());
     }
 
     private List<Bed> getNextBeds(Admin admin, Camera camera, int size) {

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/AdminNurseController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/AdminNurseController.java
@@ -4,12 +4,12 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -24,7 +24,6 @@ import aurora.carevisionapiserver.domain.nurse.dto.request.NurseRequest.NurseReg
 import aurora.carevisionapiserver.domain.nurse.dto.response.NurseResponse.NursePreviewListResponse;
 import aurora.carevisionapiserver.domain.nurse.dto.response.NurseResponse.NursePreviewPageResponse;
 import aurora.carevisionapiserver.domain.nurse.service.NurseService;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.common.service.PageService;
 import aurora.carevisionapiserver.global.response.BaseResponse;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
@@ -53,8 +52,9 @@ public class AdminNurseController {
     @GetMapping("/nurses")
     public BaseResponse<NursePreviewPageResponse> getNurseList(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
-            @RequestBody PageRequest request) {
-        Slice<Nurse> nurses = nurseService.getActiveNurses(admin, request);
+            @RequestParam(value = "lastIdx") Long lastIdx,
+            @PageableDefault(size = 8, sort = "id") @RequestParam(value = "size") int size) {
+        Slice<Nurse> nurses = nurseService.getActiveNurses(admin, lastIdx, size);
         return BaseResponse.onSuccess(
                 NurseConverter.toNursePreviewPageResponse(
                         nurses, pageService.getNextCursor(nurses.getContent())));

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/api/NurseController.java
@@ -3,6 +3,7 @@ package aurora.carevisionapiserver.domain.nurse.api;
 import java.util.HashMap;
 
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,7 +28,6 @@ import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.Pati
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientProfilePageResponse;
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.common.service.ConnectService;
 import aurora.carevisionapiserver.global.common.service.PageService;
 import aurora.carevisionapiserver.global.fcm.dto.response.AlarmPreviewResponse;
@@ -76,8 +76,9 @@ public class NurseController {
     @GetMapping("/patients")
     public BaseResponse<PatientProfilePageResponse> getPatientList(
             @Parameter(name = "nurse", hidden = true) @AuthUser Nurse nurse,
-            @RequestBody PageRequest request) {
-        Slice<Patient> patients = patientService.getPatientSlice(nurse, request);
+            @RequestParam(value = "lastIdx") Long lastIdx,
+            @PageableDefault(size = 8, sort = "id") @RequestParam(value = "size") int size) {
+        Slice<Patient> patients = patientService.getPatientSlice(nurse, lastIdx, size);
 
         return BaseResponse.of(
                 SuccessStatus._OK,

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/service/Impl/NurseServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/service/Impl/NurseServiceImpl.java
@@ -19,7 +19,6 @@ import aurora.carevisionapiserver.domain.nurse.exception.NurseException;
 import aurora.carevisionapiserver.domain.nurse.repository.NurseEsRepository;
 import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
 import aurora.carevisionapiserver.domain.nurse.service.NurseService;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 
@@ -64,9 +63,8 @@ public class NurseServiceImpl implements NurseService {
     }
 
     @Override
-    public Slice<Nurse> getActiveNurses(Admin admin, PageRequest request) {
-        return nurseRepository.findActiveNursesByAdmin(
-                admin, request.getLastIdx(), request.getSize());
+    public Slice<Nurse> getActiveNurses(Admin admin, Long lastIdx, int size) {
+        return nurseRepository.findActiveNursesByAdmin(admin, lastIdx, size);
     }
 
     @Override

--- a/src/main/java/aurora/carevisionapiserver/domain/nurse/service/NurseService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/nurse/service/NurseService.java
@@ -9,7 +9,6 @@ import aurora.carevisionapiserver.domain.hospital.domain.Department;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.domain.NurseDocument;
 import aurora.carevisionapiserver.domain.nurse.dto.request.NurseRequest.NurseCreateRequest;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 
 public interface NurseService {
     boolean existsByNurseId(Long value);
@@ -22,7 +21,7 @@ public interface NurseService {
 
     Nurse getInactiveNurse(String username);
 
-    Slice<Nurse> getActiveNurses(Admin admin, PageRequest request);
+    Slice<Nurse> getActiveNurses(Admin admin, Long lastIdx, int size);
 
     List<Nurse> getInactiveNurses(Admin admin);
 

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/api/AdminPatientController.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/api/AdminPatientController.java
@@ -3,6 +3,7 @@ package aurora.carevisionapiserver.domain.patient.api;
 import java.util.Map;
 
 import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,7 +20,6 @@ import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.Pati
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchPageResponse;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.common.service.PageService;
 import aurora.carevisionapiserver.global.response.BaseResponse;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
@@ -61,8 +61,9 @@ public class AdminPatientController {
     @GetMapping("")
     public BaseResponse<PatientSearchPageResponse> getPatients(
             @Parameter(name = "admin", hidden = true) @AuthUser Admin admin,
-            @RequestBody PageRequest request) {
-        Slice<Patient> patients = patientService.getPatients(admin, request);
+            @RequestParam(value = "lastIdx") Long lastIdx,
+            @PageableDefault(size = 8, sort = "id") @RequestParam(value = "size") int size) {
+        Slice<Patient> patients = patientService.getPatients(admin, lastIdx, size);
         return BaseResponse.onSuccess(
                 PatientConverter.toPatientSearchPageResponse(
                         patients, pageService.getNextCursor(patients.getContent())));

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/Impl/PatientServiceImpl.java
@@ -22,7 +22,6 @@ import aurora.carevisionapiserver.domain.patient.repository.PatientEsRepository;
 import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
 import aurora.carevisionapiserver.domain.patient.service.PatientRegistrationService;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.common.service.ConnectService;
 import aurora.carevisionapiserver.global.response.code.status.ErrorStatus;
 import aurora.carevisionapiserver.global.util.PatientNameUtil;
@@ -43,13 +42,13 @@ public class PatientServiceImpl implements PatientService {
     }
 
     @Override
-    public Slice<Patient> getPatients(Admin admin, PageRequest request) {
-        return patientRepository.findPatientByAdmin(admin, request.getLastIdx(), request.getSize());
+    public Slice<Patient> getPatients(Admin admin, Long lastIdx, int size) {
+        return patientRepository.findPatientByAdmin(admin, lastIdx, size);
     }
 
     @Override
-    public Slice<Patient> getPatientSlice(Nurse nurse, PageRequest request) {
-        return patientRepository.findPatientByNurse(nurse, request.getLastIdx(), request.getSize());
+    public Slice<Patient> getPatientSlice(Nurse nurse, Long lastIdx, int size) {
+        return patientRepository.findPatientByNurse(nurse, lastIdx, size);
     }
 
     @Override

--- a/src/main/java/aurora/carevisionapiserver/domain/patient/service/PatientService.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/patient/service/PatientService.java
@@ -11,16 +11,15 @@ import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.domain.PatientDocument;
 import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.PatientCreateRequest;
 import aurora.carevisionapiserver.domain.patient.dto.response.PatientResponse.PatientSearchListResponse;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 
 public interface PatientService {
     Map<PatientDocument, Bed> searchPatient(String patientName);
 
     Patient getPatient(Long patientId);
 
-    Slice<Patient> getPatients(Admin admin, PageRequest request);
+    Slice<Patient> getPatients(Admin admin, Long lastIdx, int size);
 
-    Slice<Patient> getPatientSlice(Nurse nurse, PageRequest request);
+    Slice<Patient> getPatientSlice(Nurse nurse, Long lastIdx, int size);
 
     void deletePatient(Long patientId);
 

--- a/src/test/java/aurora/carevisionapiserver/domain/camera/api/AdminCameraControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/camera/api/AdminCameraControllerTest.java
@@ -1,6 +1,8 @@
 package aurora.carevisionapiserver.domain.camera.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +20,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import aurora.carevisionapiserver.ControllerTestSupport;
 import aurora.carevisionapiserver.domain.camera.domain.Camera;
-import aurora.carevisionapiserver.global.common.dto.request.PageForCameraRequest;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
 
 class AdminCameraControllerTest extends ControllerTestSupport {
@@ -27,18 +28,18 @@ class AdminCameraControllerTest extends ControllerTestSupport {
     @Test
     void getCameras() throws Exception {
         // given
-        PageForCameraRequest request = new PageForCameraRequest("CAM1", 2);
         Slice<Camera> cameras = new SliceImpl<>(List.of());
 
         // when //then
-        when(cameraService.getAllCameraInfo(any(), any())).thenReturn(cameras);
+        when(cameraService.getAllCameraInfo(any(), anyString(), anyInt())).thenReturn(cameras);
         when(pageService.getNextCursorForCameras(any())).thenReturn("CAM2");
 
         mockMvc.perform(
                         get("/api/admin/cameras")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(csrf())
-                                .content(objectMapper.writeValueAsString(request)))
+                                .param("cameraId", "CAM1")
+                                .param("size", "8"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessStatus._OK.getCode()))
                 .andExpect(jsonPath("$.result.cameraInfoList").isArray())

--- a/src/test/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/camera/api/NurseCameraControllerTest.java
@@ -1,6 +1,7 @@
 package aurora.carevisionapiserver.domain.camera.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -22,7 +23,6 @@ import aurora.carevisionapiserver.ControllerTestSupport;
 import aurora.carevisionapiserver.domain.bed.domain.Bed;
 import aurora.carevisionapiserver.domain.camera.dto.response.CameraResponse.VideoInfoResponse;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
 
 class NurseCameraControllerTest extends ControllerTestSupport {
@@ -31,14 +31,12 @@ class NurseCameraControllerTest extends ControllerTestSupport {
     @Test
     void getStreamingInfoList() throws Exception {
         // given
-        PageRequest request = new PageRequest(-1L, 2);
-
         Bed bed = Bed.builder().bedNumber(1L).patientRoomNumber(2L).inpatientWardNumber(3L).build();
         Patient patient = Patient.builder().id(1L).bed(bed).build();
         Slice<Patient> patientSlice = new SliceImpl<>(List.of(patient));
 
         // when //then
-        when(patientService.getPatientSlice(any(), any())).thenReturn(patientSlice);
+        when(patientService.getPatientSlice(any(), anyLong(), anyInt())).thenReturn(patientSlice);
         when(cameraService.getStreamingInfo(any()))
                 .thenReturn(Collections.singletonMap(patientSlice.getContent().get(0), "info"));
         when(pageService.getNextCursor(any())).thenReturn(1L);
@@ -47,7 +45,8 @@ class NurseCameraControllerTest extends ControllerTestSupport {
                         get("/api/streaming")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(csrf())
-                                .content(objectMapper.writeValueAsString(request)))
+                                .param("lastIdx", "0")
+                                .param("size", "8"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessStatus._OK.getCode()))
                 .andExpect(jsonPath("$.result.streamingResponse").isArray())
@@ -60,20 +59,20 @@ class NurseCameraControllerTest extends ControllerTestSupport {
     @Test
     void getSavedVideoInfos() throws Exception {
         // given
-        PageRequest request = new PageRequest(-1L, 2);
-
         VideoInfoResponse response = VideoInfoResponse.builder().build();
         Slice<VideoInfoResponse> videoInfo = new SliceImpl<>(List.of(response));
 
         // when //then
-        when(cameraService.getSavedVideoInfos(anyLong(), any())).thenReturn(videoInfo);
+        when(cameraService.getSavedVideoInfos(anyLong(), anyLong(), anyInt()))
+                .thenReturn(videoInfo);
         when(pageService.getNextCursor(any())).thenReturn(1L);
 
         mockMvc.perform(
                         get("/api/patients/{patientId}/videos", 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(csrf())
-                                .content(objectMapper.writeValueAsString(request)))
+                                .param("lastIdx", "0")
+                                .param("size", "8"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessStatus._OK.getCode()))
                 .andExpect(jsonPath("$.result.videoInfoList").isArray())

--- a/src/test/java/aurora/carevisionapiserver/domain/camera/service/CameraServiceTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/camera/service/CameraServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,8 +37,6 @@ import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
-import aurora.carevisionapiserver.global.common.dto.request.PageForCameraRequest;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 
 class CameraServiceTest extends IntegrationTestSupport {
     @Autowired PatientRepository patientRepository;
@@ -52,11 +51,24 @@ class CameraServiceTest extends IntegrationTestSupport {
     @Autowired CameraService cameraService;
     @MockBean PatientService patientService;
 
+    @AfterEach
+    void tearDown() {
+        bedRepository.deleteAllInBatch();
+        videoRepository.deleteAllInBatch();
+        patientRepository.deleteAllInBatch();
+        adminRepository.deleteAllInBatch();
+        nurseRepository.deleteAllInBatch();
+        departmentRepository.deleteAllInBatch();
+        hospitalRepository.deleteAllInBatch();
+        cameraRepository.deleteAllInBatch();
+    }
+
     @DisplayName("저장된 비디오의 정보를 조회한다.")
     @Test
     void getSavedVideoInfos() {
         // given
-        PageRequest request = new PageRequest(-1L, 2);
+        Long lastIdx = -1L;
+        int size = 2;
 
         Department department = createDepartment();
         Nurse nurse = createNurse(department);
@@ -78,7 +90,7 @@ class CameraServiceTest extends IntegrationTestSupport {
         when(customVideoRepository.findByPatient(any(Patient.class), anyLong(), anyInt()))
                 .thenReturn(new SliceImpl<>(videos));
         Slice<VideoInfoResponse> response =
-                cameraService.getSavedVideoInfos(patient.getId(), request);
+                cameraService.getSavedVideoInfos(patient.getId(), lastIdx, size);
 
         // then
         assertThat(response.getContent())
@@ -89,9 +101,9 @@ class CameraServiceTest extends IntegrationTestSupport {
                         video2.getCreatedAt().format(formatter));
     }
 
-    @DisplayName("관리자 과의 모든 카메라 정보를 페이지 처리해 조회한다.")
+    @DisplayName("관리자 과의 모든 카메라 정보를 페이지 처리해 조회한다. 다음으로 조회될 카메라는 없다.")
     @Test
-    void getAllCameraInfo() {
+    void getAllCameraInfoWhenHasNextIsFalse() {
         // given
         Department department = createDepartment();
         Camera camera0 = createCamera("CAM0");
@@ -100,22 +112,47 @@ class CameraServiceTest extends IntegrationTestSupport {
         Camera camera1 = createCamera("CAM1");
         Camera camera2 = createCamera("CAM2");
         Camera camera3 = createCamera("CAM3");
-        Bed bed1 = createBed(1L, 2L, 1L, department, camera1);
-        Bed bed2 = createBed(1L, 2L, 2L, department, camera2);
-        Bed bed3 = createBed(2L, 1L, 3L, department, camera3);
-        List<Bed> beds = List.of(bed1, bed2, bed3);
-
+        createBed(1L, 2L, 2L, department, camera1);
+        createBed(1L, 2L, 1L, department, camera2);
+        createBed(1L, 1L, 3L, department, camera3);
         Admin admin = createAdmin(department);
-        PageForCameraRequest request = new PageForCameraRequest("CAM0", 3);
 
         // when
-        Slice<Camera> response = cameraService.getAllCameraInfo(admin, request);
+        Slice<Camera> response = cameraService.getAllCameraInfo(admin, "CAM0", 3);
 
         // then
         assertThat(response.getContent())
                 .hasSize(3)
                 .extracting("id")
-                .contains("CAM1", "CAM2", "CAM3");
+                .containsExactly("CAM3", "CAM2", "CAM1");
+        assertThat(response.hasNext()).isFalse();
+    }
+
+    @DisplayName("관리자 과의 모든 카메라 정보를 페이지 처리해 조회한다. 다음으로 조회될 카메라가 있다.")
+    @Test
+    void getAllCameraInfoWhenHasNextIsTrue() {
+        // given
+        Department department = createDepartment();
+        Camera camera0 = createCamera("CAM0");
+        createBed(1L, 1L, 1L, department, camera0);
+
+        Camera camera1 = createCamera("CAM1");
+        Camera camera2 = createCamera("CAM2");
+        Camera camera3 = createCamera("CAM3");
+        createBed(1L, 2L, 2L, department, camera1);
+        createBed(1L, 2L, 1L, department, camera2);
+        createBed(1L, 1L, 3L, department, camera3);
+        Admin admin = createAdmin(department);
+
+        // when
+        Slice<Camera> response = cameraService.getAllCameraInfo(admin, "CAM0", 2);
+
+        // then
+        assertThat(response.getContent())
+                .hasSize(2)
+                .extracting("id")
+                .containsExactly("CAM3", "CAM2");
+        assertThat(response.hasNext()).isTrue();
     }
 
     private Camera createCamera(String id) {

--- a/src/test/java/aurora/carevisionapiserver/domain/nurse/api/AdminNurseControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/nurse/api/AdminNurseControllerTest.java
@@ -1,6 +1,8 @@
 package aurora.carevisionapiserver.domain.nurse.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +20,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import aurora.carevisionapiserver.ControllerTestSupport;
 import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
 
 class AdminNurseControllerTest extends ControllerTestSupport {
@@ -27,13 +28,11 @@ class AdminNurseControllerTest extends ControllerTestSupport {
     @Test
     void getNurseList() throws Exception {
         // given
-        PageRequest request = new PageRequest(-1L, 2);
-
         Nurse nurse = Nurse.builder().build();
         Slice<Nurse> nurses = new SliceImpl<>(List.of(nurse));
 
         // when
-        when(nurseService.getActiveNurses(any(), any())).thenReturn(nurses);
+        when(nurseService.getActiveNurses(any(), anyLong(), anyInt())).thenReturn(nurses);
         when(pageService.getNextCursor(any())).thenReturn(1L);
 
         // then
@@ -41,7 +40,8 @@ class AdminNurseControllerTest extends ControllerTestSupport {
                         get("/api/admin/nurses")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(csrf())
-                                .content(objectMapper.writeValueAsString(request)))
+                                .param("lastIdx", "0")
+                                .param("size", "2"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessStatus._OK.getCode()))
                 .andExpect(jsonPath("$.result.nurseList").isArray())

--- a/src/test/java/aurora/carevisionapiserver/domain/nurse/api/NurseControllerIntegrationTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/nurse/api/NurseControllerIntegrationTest.java
@@ -1,6 +1,8 @@
 package aurora.carevisionapiserver.domain.nurse.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -20,8 +22,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import aurora.carevisionapiserver.IntegrationTestSupport;
 import aurora.carevisionapiserver.domain.bed.domain.Bed;
 import aurora.carevisionapiserver.domain.bed.repository.BedRepository;
@@ -34,14 +34,12 @@ import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
 import aurora.carevisionapiserver.domain.patient.service.PatientService;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.common.service.PageService;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
 
 @AutoConfigureMockMvc
 public class NurseControllerIntegrationTest extends IntegrationTestSupport {
     @Autowired MockMvc mockMvc;
-    @Autowired ObjectMapper objectMapper;
     @Autowired PatientRepository patientRepository;
     @Autowired DepartmentRepository departmentRepository;
     @Autowired HospitalRepository hospitalRepository;
@@ -57,8 +55,6 @@ public class NurseControllerIntegrationTest extends IntegrationTestSupport {
     @Test
     void getPatientList() throws Exception {
         // given
-        PageRequest request = new PageRequest(-1L, 2);
-
         Department department = createDepartment();
         Nurse nurse = createNurse(department);
         Bed bed = createBed(department);
@@ -67,7 +63,8 @@ public class NurseControllerIntegrationTest extends IntegrationTestSupport {
         Slice<Patient> patientSlice = new SliceImpl<>(List.of(patient));
 
         // when
-        when(patientService.getPatientSlice(any(Nurse.class), any())).thenReturn(patientSlice);
+        when(patientService.getPatientSlice(any(Nurse.class), anyLong(), anyInt()))
+                .thenReturn(patientSlice);
         when(pageService.getNextCursor(any())).thenReturn(1L);
 
         // then
@@ -75,7 +72,8 @@ public class NurseControllerIntegrationTest extends IntegrationTestSupport {
                         get("/api/patients")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(csrf())
-                                .content(objectMapper.writeValueAsString(request)))
+                                .param("lastIdx", "0")
+                                .param("size", "2"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessStatus._OK.getCode()))
                 .andExpect(jsonPath("$.result.patients").isArray())

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/api/AdminPatientControllerTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/api/AdminPatientControllerTest.java
@@ -1,6 +1,8 @@
 package aurora.carevisionapiserver.domain.patient.api;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +20,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import aurora.carevisionapiserver.ControllerTestSupport;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
-import aurora.carevisionapiserver.global.common.dto.request.PageRequest;
 import aurora.carevisionapiserver.global.response.code.status.SuccessStatus;
 
 class AdminPatientControllerTest extends ControllerTestSupport {
@@ -27,18 +28,18 @@ class AdminPatientControllerTest extends ControllerTestSupport {
     @Test
     void getPatients() throws Exception {
         // given
-        PageRequest request = new PageRequest(-1L, 2);
         Slice<Patient> patientSlice = new SliceImpl<>(List.of());
 
         // when //then
-        when(patientService.getPatients(any(), any())).thenReturn(patientSlice);
+        when(patientService.getPatients(any(), anyLong(), anyInt())).thenReturn(patientSlice);
         when(pageService.getNextCursor(any())).thenReturn(1L);
 
         mockMvc.perform(
                         get("/api/admin/patients")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(csrf())
-                                .content(objectMapper.writeValueAsString(request)))
+                                .param("lastIdx", "0")
+                                .param("size", "8"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(SuccessStatus._OK.getCode()))
                 .andExpect(jsonPath("$.result.patientList").isArray())

--- a/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceConcurrencyTest.java
+++ b/src/test/java/aurora/carevisionapiserver/domain/patient/service/PatientServiceConcurrencyTest.java
@@ -1,4 +1,4 @@
-package aurora.carevisionapiserver.domain.patient.service.Impl;
+package aurora.carevisionapiserver.domain.patient.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -30,9 +30,8 @@ import aurora.carevisionapiserver.domain.nurse.service.NurseService;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.dto.request.PatientRequest.PatientCreateRequest;
 import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
-import aurora.carevisionapiserver.domain.patient.service.PatientService;
 
-class PatientServiceImplConcurrencyTest extends IntegrationTestSupport {
+class PatientServiceConcurrencyTest extends IntegrationTestSupport {
     @Autowired PatientRepository patientRepository;
     @Autowired NurseRepository nurseRepository;
     @Autowired DepartmentRepository departmentRepository;

--- a/src/test/java/aurora/carevisionapiserver/global/common/service/ConnectServiceTest.java
+++ b/src/test/java/aurora/carevisionapiserver/global/common/service/ConnectServiceTest.java
@@ -1,4 +1,4 @@
-package aurora.carevisionapiserver.global.common.service.impl;
+package aurora.carevisionapiserver.global.common.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -20,9 +20,8 @@ import aurora.carevisionapiserver.domain.nurse.domain.Nurse;
 import aurora.carevisionapiserver.domain.nurse.repository.NurseRepository;
 import aurora.carevisionapiserver.domain.patient.domain.Patient;
 import aurora.carevisionapiserver.domain.patient.repository.PatientRepository;
-import aurora.carevisionapiserver.global.common.service.ConnectService;
 
-class ConnectServiceImplTest extends IntegrationTestSupport {
+class ConnectServiceTest extends IntegrationTestSupport {
     @Autowired PatientRepository patientRepository;
     @Autowired NurseRepository nurseRepository;
     @Autowired DepartmentRepository departmentRepository;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #205

## 📌 개요
- DTO로 입력받던 방식에서 https://github.com/SSU-Capstone-Aurora/CareVision-Backend/pull/195 이 방법으로 다시 수정했습니다. 
수정하면서 `카메라 조회 기능`에서 Bed에 따른 카메라 ID 리스트의 순서를 보장하지 않고 있다는 것을 확인했고, 순서 유지되도록 수정했습니다. => 2e479e06f0c67468cb3e9e58b617e5d8a7bdae72 


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
