### PR TITLE
[refactor] 카메라 조회시 N+1 문제 해결을 위해 fetch join 적용

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/domain/bed/repository/impl/CustomBedRepositoryImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/bed/repository/impl/CustomBedRepositoryImpl.java
@@ -24,9 +24,9 @@ public class CustomBedRepositoryImpl implements CustomBedRepository {
         QBed bed = QBed.bed;
         return queryFactory
                 .selectFrom(bed)
-                .leftJoin(QDepartment.department)
-                .on(isEqualToDepartment(bed, department))
-                .where(findBedsGreaterThan(bed, lastBed))
+                .leftJoin(bed.department, QDepartment.department)
+                .fetchJoin()
+                .where(isEqualToDepartment(bed, department), findBedsGreaterThan(bed, lastBed))
                 .orderBy(
                         bed.inpatientWardNumber.asc(),
                         bed.patientRoomNumber.asc(),

--- a/src/main/java/aurora/carevisionapiserver/domain/bed/repository/impl/CustomBedRepositoryImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/bed/repository/impl/CustomBedRepositoryImpl.java
@@ -40,23 +40,25 @@ public class CustomBedRepositoryImpl implements CustomBedRepository {
     }
 
     private static BooleanExpression findBedsGreaterThan(QBed bed, Bed lastBed) {
-        return bed.id
-                .ne(lastBed.getId())
-                .and(
-                        bed.inpatientWardNumber
-                                .gt(lastBed.getInpatientWardNumber())
-                                .or(
-                                        bed.inpatientWardNumber
-                                                .eq(lastBed.getInpatientWardNumber())
-                                                .and(
-                                                        bed.patientRoomNumber.gt(
-                                                                lastBed.getPatientRoomNumber())))
-                                .or(
-                                        bed.inpatientWardNumber
-                                                .eq(lastBed.getInpatientWardNumber())
-                                                .and(
-                                                        bed.patientRoomNumber.eq(
-                                                                lastBed.getPatientRoomNumber()))
-                                                .and(bed.bedNumber.gt(lastBed.getBedNumber()))));
+        return findConditionForWardNumber(bed, lastBed)
+                .or(findConditionForPatientRoomNumber(bed, lastBed))
+                .or(findConditionForBedNumber(bed, lastBed));
+    }
+
+    private static BooleanExpression findConditionForWardNumber(QBed bed, Bed lastBed) {
+        return bed.ne(lastBed).and(bed.inpatientWardNumber.gt(lastBed.getInpatientWardNumber()));
+    }
+
+    private static BooleanExpression findConditionForPatientRoomNumber(QBed bed, Bed lastBed) {
+        return bed.inpatientWardNumber
+                .eq(lastBed.getInpatientWardNumber())
+                .and(bed.patientRoomNumber.gt(lastBed.getPatientRoomNumber()));
+    }
+
+    private static BooleanExpression findConditionForBedNumber(QBed bed, Bed lastBed) {
+        return bed.inpatientWardNumber
+                .eq(lastBed.getInpatientWardNumber())
+                .and(bed.patientRoomNumber.eq(lastBed.getPatientRoomNumber()))
+                .and(bed.bedNumber.gt(lastBed.getBedNumber()));
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
+++ b/src/main/java/aurora/carevisionapiserver/domain/camera/service/Impl/CameraServiceImpl.java
@@ -63,7 +63,7 @@ public class CameraServiceImpl implements CameraService {
     private List<Camera> getCamerasByBeds(List<Bed> beds) {
         List<String> cameraIds = beds.stream().map(bed -> bed.getCamera().getId()).toList();
 
-        return cameraIds.stream().map(id -> getCameraById(id)).collect(Collectors.toList());
+        return cameraIds.stream().map(this::getCameraById).collect(Collectors.toList());
     }
 
     private List<Bed> getNextBeds(Admin admin, Camera camera, int size) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #204 

## 📌 개요
- 테스트 코드에서 분명 개수대로 조회되던 것들이.. 실제 서버에서 request를 날려보니 size의 개수에 상관없이 무조건 하나만 조회되는 것을 확인했습니다
<img src="https://github.com/user-attachments/assets/cc23e841-2a1d-4ae3-aef1-6f64eec7991b" width="50%" />

-> 이전 코드에서는 QDepartment.department를 독립적인 테이블로 취급하여 조인하고 있어 조인된 데이터가 올바르게 매핑되지 않을 가능성이 있었고,` on(isEqualToDepartment(bed, department)) `조건이 ManyToOne 관계에서 불필요하다고 합니다. 
=> JPA에서는` @ManyToOne `관계에서 자동으로 FK 매핑을 수행하기 때문에, on 조건을 직접 작성하면 조인 방식이 꼬일 수 있다고 하네요

또한 leftJoin()을 사용하면서 fetchJoin()을 사용하지 않았었는데, 그로 인해 JPA가 Lazy Loading을 적용하여 Department가 제대로 조회되지 않고, 예상보다 적은 데이터가 반환될 수 있다고 합니다. 


이전 쿼리문을 살펴보니 
Bed와 Department의 연관관계는 **ManyToOne**이며 Bed가 Department를 참조하는 구조인데,
```
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "department_id", nullable = false)
    private Department department;
```
Bed를 조회할 때 Department가 **Lazy Loading**이기 때문에 추가 쿼리가 발생합니다. 

기존 코드에서는 leftJoin()을 사용했지만, fetchJoin()이 없기 때문에 bed.getDepartment()를 호출할 때마다 개별 select 쿼리가 실행됩니다!=>` N+1 문제`가 발생했던 것입니다 

🔹`fetchJoin()` 사용해서 Bed와 Department가 한 번의 쿼리로 함께 로드되도록 했습니다. 
=> bed.getDepartment()를 호출해도 추가적인 SELECT 쿼리가 발생하지 않게 되었고, 쿼리문 개수는 하나로 날라가는 것을 확인했고 size에 맞게 조회되는 것을 확인했습니다!
<img src="https://github.com/user-attachments/assets/805fdbf2-7d09-4060-a524-376b778d3e56" width="50%" />


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
