### PR TITLE
[chore] API 요청별 쿼리 카운터 구현

### DIFF
--- a/src/main/java/aurora/carevisionapiserver/global/config/WebConfig.java
+++ b/src/main/java/aurora/carevisionapiserver/global/config/WebConfig.java
@@ -5,8 +5,10 @@ import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import aurora.carevisionapiserver.global.query.LoggingInterceptor;
 import aurora.carevisionapiserver.global.security.handler.resolver.AuthUserArgumentResolver;
 import aurora.carevisionapiserver.global.security.handler.resolver.ExtractTokenArgumentResolver;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class WebConfig implements WebMvcConfigurer {
     private final AuthUserArgumentResolver authUserArgumentResolver;
     private final ExtractTokenArgumentResolver extractTokenArgumentResolver;
+    private final LoggingInterceptor loggingInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -31,5 +34,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authUserArgumentResolver);
         resolvers.add(extractTokenArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor).addPathPatterns("/**");
     }
 }

--- a/src/main/java/aurora/carevisionapiserver/global/query/ApiQueryCounter.java
+++ b/src/main/java/aurora/carevisionapiserver/global/query/ApiQueryCounter.java
@@ -1,0 +1,18 @@
+package aurora.carevisionapiserver.global.query;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import lombok.Getter;
+
+@Component
+@RequestScope
+@Getter
+public class ApiQueryCounter {
+
+    private int count;
+
+    public void increaseCount() {
+        count++;
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/global/query/ApiQueryCounterAop.java
+++ b/src/main/java/aurora/carevisionapiserver/global/query/ApiQueryCounterAop.java
@@ -1,0 +1,28 @@
+package aurora.carevisionapiserver.global.query;
+
+import java.lang.reflect.Proxy;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+public class ApiQueryCounterAop {
+
+    private final ApiQueryCounter apiQueryCounter;
+
+    public ApiQueryCounterAop(final ApiQueryCounter apiQueryCounter) {
+        this.apiQueryCounter = apiQueryCounter;
+    }
+
+    @Around("execution(* javax.sql.DataSource.getConnection())")
+    public Object getConnection(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object connection = proceedingJoinPoint.proceed();
+        return Proxy.newProxyInstance(
+                connection.getClass().getClassLoader(),
+                connection.getClass().getInterfaces(),
+                new ConnectionProxyHandler(connection, apiQueryCounter));
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/global/query/ConnectionProxyHandler.java
+++ b/src/main/java/aurora/carevisionapiserver/global/query/ConnectionProxyHandler.java
@@ -1,0 +1,29 @@
+package aurora.carevisionapiserver.global.query;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+public class ConnectionProxyHandler implements InvocationHandler {
+
+    private final Object connection;
+    private final ApiQueryCounter apiQueryCounter;
+
+    public ConnectionProxyHandler(final Object connection, final ApiQueryCounter apiQueryCounter) {
+        this.connection = connection;
+        this.apiQueryCounter = apiQueryCounter;
+    }
+
+    @Override
+    public Object invoke(final Object proxy, final Method method, final Object[] args)
+            throws Throwable {
+        Object invokeResult = method.invoke(connection, args);
+        if (method.getName().equals("prepareStatement")) {
+            return Proxy.newProxyInstance(
+                    invokeResult.getClass().getClassLoader(),
+                    invokeResult.getClass().getInterfaces(),
+                    new PreparedStatementProxyHandler(invokeResult, apiQueryCounter));
+        }
+        return invokeResult;
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/global/query/LoggingInterceptor.java
+++ b/src/main/java/aurora/carevisionapiserver/global/query/LoggingInterceptor.java
@@ -1,0 +1,45 @@
+package aurora.carevisionapiserver.global.query;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+
+    private static final String QUERY_COUNT_LOG_FORMAT =
+            "STATUS_CODE: {}, METHOD: {}, URL: {}, QUERY_COUNT: {}";
+    private static final String QUERY_COUNT_WARNING_LOG_FORMAT = "쿼리가 {}번 이상 실행되었습니다.";
+
+    private static final int QUERY_COUNT_WARNING_STANDARD = 10;
+
+    private final ApiQueryCounter apiQueryCounter;
+
+    public LoggingInterceptor(final ApiQueryCounter apiQueryCounter) {
+        this.apiQueryCounter = apiQueryCounter;
+    }
+
+    @Override
+    public void afterCompletion(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Object handler,
+            final Exception ex) {
+        final int queryCount = apiQueryCounter.getCount();
+
+        log.info(
+                QUERY_COUNT_LOG_FORMAT,
+                response.getStatus(),
+                request.getMethod(),
+                request.getRequestURI(),
+                queryCount);
+        if (queryCount >= QUERY_COUNT_WARNING_STANDARD) {
+            log.warn(QUERY_COUNT_WARNING_LOG_FORMAT, QUERY_COUNT_WARNING_STANDARD);
+        }
+    }
+}

--- a/src/main/java/aurora/carevisionapiserver/global/query/PreparedStatementProxyHandler.java
+++ b/src/main/java/aurora/carevisionapiserver/global/query/PreparedStatementProxyHandler.java
@@ -1,0 +1,39 @@
+package aurora.carevisionapiserver.global.query;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import org.springframework.web.context.request.RequestContextHolder;
+
+public class PreparedStatementProxyHandler implements InvocationHandler {
+
+    private final Object preparedStatement;
+    private final ApiQueryCounter apiQueryCounter;
+
+    public PreparedStatementProxyHandler(
+            final Object preparedStatement, final ApiQueryCounter apiQueryCounter) {
+        this.preparedStatement = preparedStatement;
+        this.apiQueryCounter = apiQueryCounter;
+    }
+
+    @Override
+    public Object invoke(final Object proxy, final Method method, final Object[] args)
+            throws Throwable {
+        if (isExecuteQuery(method) && isInRequestScope()) {
+            apiQueryCounter.increaseCount();
+        }
+        return method.invoke(preparedStatement, args);
+    }
+
+    private boolean isExecuteQuery(final Method method) {
+        String methodName = method.getName();
+        return methodName.equals("executeQuery")
+                || methodName.equals("execute")
+                || methodName.equals("executeUpdate");
+    }
+
+    private boolean isInRequestScope() {
+        return Objects.nonNull(RequestContextHolder.getRequestAttributes());
+    }
+}

--- a/src/test/java/aurora/carevisionapiserver/ControllerTestSupport.java
+++ b/src/test/java/aurora/carevisionapiserver/ControllerTestSupport.java
@@ -22,6 +22,7 @@ import aurora.carevisionapiserver.global.auth.util.JWTUtil;
 import aurora.carevisionapiserver.global.common.service.ConnectService;
 import aurora.carevisionapiserver.global.common.service.PageService;
 import aurora.carevisionapiserver.global.fcm.service.FcmService;
+import aurora.carevisionapiserver.global.query.ApiQueryCounter;
 
 @WebMvcTest(
         controllers = {
@@ -45,4 +46,5 @@ public abstract class ControllerTestSupport {
     @MockBean protected AdminRepository adminRepository;
     @MockBean protected FcmService fcmService;
     @MockBean protected ConnectService connectService;
+    @MockBean protected ApiQueryCounter apiQueryCounter;
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #210 

## 📌 개요
- https://github.com/SSU-Capstone-Aurora/CareVision-Backend/pull/209 해당 문제를 해결하기 위해, 쿼리문을 카운트 하는 기능을 추가했습니다. 
- 해당 기능을 구현하기 위해 AOP와 [다이나믹프록시](https://88dldl.tistory.com/166)에 대해 공부하고, [쿼리카운터 구현기 게시글](https://velog.io/@ohzzi/API%EC%9D%98-%EC%BF%BC%EB%A6%AC-%EA%B0%9C%EC%88%98-%EC%84%B8%EA%B8%B0-2-JDBC-Spring-AOP-Dynamic-Proxy%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%B9%B4%EC%9A%B4%ED%8C%85) 참고했습니다!

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
